### PR TITLE
contracts: fix test warnings

### DIFF
--- a/contracts/AMM.sol
+++ b/contracts/AMM.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "./utils/NoDelegateCall.sol";
 import "./core_libraries/Tick.sol";

--- a/contracts/AMMDeployer.sol
+++ b/contracts/AMMDeployer.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "./interfaces/IAMMDeployer.sol";
@@ -5,61 +7,61 @@ import "./AMM.sol";
 import "./core_libraries/FixedAndVariableMath.sol";
 
 contract AMMDeployer is IAMMDeployer {
-    struct Parameters {
-        address factory;
-        address underlyingToken;
-        bytes32 rateOracleId;
-        uint256 termStartTimestamp;
-        uint256 termEndTimestamp;
-        uint24 fee;
-        int24 tickSpacing;
-    }
+  struct Parameters {
+    address factory;
+    address underlyingToken;
+    bytes32 rateOracleId;
+    uint256 termStartTimestamp;
+    uint256 termEndTimestamp;
+    uint24 fee;
+    int24 tickSpacing;
+  }
 
-    /// @inheritdoc IAMMDeployer
-    Parameters public override parameters;
+  /// @inheritdoc IAMMDeployer
+  Parameters public override parameters;
 
-    /// @dev Deploys an amm with the given parameters by transiently setting the parameters storage slot and then
-    /// clearing it after deploying the amm.
-    /// @param factory The contract address of the Voltz factory
-    /// @param underlyingToken The contract address of the token in the underlying pool
-    /// @param rateOracleId rate oracle id
-    /// @param termEndTimestamp Number of days between the inception of the pool and its maturity
-    /// @param fee The fee collected upon every swap in the pool (as a percentage of notional traded), denominated in hundredths of a bip
-    /// @param tickSpacing The spacing between usable ticks
-    function deploy(
-        address factory,
-        address underlyingToken,
-        bytes32 rateOracleId,
-        uint termStartTimestamp,
-        uint256 termEndTimestamp,
-        uint24 fee,
-        int24 tickSpacing
-    ) internal returns (address amm) {
-        // uint256 _termStartTimestamp = FixedAndVariableMath.blockTimestampScaled();
-        
-        parameters = Parameters({
-            factory: factory,
-            underlyingToken: underlyingToken,
-            rateOracleId: rateOracleId,
-            termStartTimestamp: termStartTimestamp,
-            termEndTimestamp: termEndTimestamp,
-            fee: fee,
-            tickSpacing: tickSpacing
-        });
+  /// @dev Deploys an amm with the given parameters by transiently setting the parameters storage slot and then
+  /// clearing it after deploying the amm.
+  /// @param factory The contract address of the Voltz factory
+  /// @param underlyingToken The contract address of the token in the underlying pool
+  /// @param rateOracleId rate oracle id
+  /// @param termEndTimestamp Number of days between the inception of the pool and its maturity
+  /// @param fee The fee collected upon every swap in the pool (as a percentage of notional traded), denominated in hundredths of a bip
+  /// @param tickSpacing The spacing between usable ticks
+  function deploy(
+    address factory,
+    address underlyingToken,
+    bytes32 rateOracleId,
+    uint256 termStartTimestamp,
+    uint256 termEndTimestamp,
+    uint24 fee,
+    int24 tickSpacing
+  ) internal returns (address amm) {
+    // uint256 _termStartTimestamp = FixedAndVariableMath.blockTimestampScaled();
 
-        amm = address(
-            new AMM{
-                salt: keccak256(
-                    abi.encode(
-                        rateOracleId,
-                        underlyingToken, // todo: redundunt since the rateOracleId incorporates the underlying token?
-                        termStartTimestamp,
-                        termEndTimestamp,
-                        fee
-                    )
-                )
-            }()
-        );
-        delete parameters;
-    }
+    parameters = Parameters({
+      factory: factory,
+      underlyingToken: underlyingToken,
+      rateOracleId: rateOracleId,
+      termStartTimestamp: termStartTimestamp,
+      termEndTimestamp: termEndTimestamp,
+      fee: fee,
+      tickSpacing: tickSpacing
+    });
+
+    amm = address(
+      new AMM{
+        salt: keccak256(
+          abi.encode(
+            rateOracleId,
+            underlyingToken, // todo: redundunt since the rateOracleId incorporates the underlying token?
+            termStartTimestamp,
+            termEndTimestamp,
+            fee
+          )
+        )
+      }()
+    );
+    delete parameters;
+  }
 }

--- a/contracts/AMMFactory.sol
+++ b/contracts/AMMFactory.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "./interfaces/IAMMFactory.sol";
@@ -13,130 +14,136 @@ import "./core_libraries/FixedAndVariableMath.sol";
 /// @title Canonical Voltz factory
 /// @notice Deploys Voltz AMMs and manages ownership and control over amm protocol fees
 contract AMMFactory is IAMMFactory, AMMDeployer, NoDelegateCall {
-    
-    mapping(bytes32 => address) public override getRateOracleAddress;
-    address public override owner;
-    mapping(uint24 => int24) public override feeAmountTickSpacing;
-    mapping(bytes32 => mapping(address => mapping(uint256 => mapping(uint256 => mapping(uint24 => address))))) public getAMMMAp;
+  mapping(bytes32 => address) public override getRateOracleAddress;
+  address public override owner;
+  mapping(uint24 => int24) public override feeAmountTickSpacing;
+  mapping(bytes32 => mapping(address => mapping(uint256 => mapping(uint256 => mapping(uint24 => address)))))
+    public getAMMMAp;
 
-    address public override treasury;
+  address public override treasury;
 
-    address public override insuranceFund;
+  address public override insuranceFund;
 
-    address public override calculator;
+  address public override calculator;
 
-    constructor(address _treasury, address _insuranceFund) {
+  constructor(address _treasury, address _insuranceFund) {
+    require(_treasury != address(0), "ZERO_ADDRESS");
+    require(_insuranceFund != address(0), "ZERO_ADDRESS");
+    treasury = _treasury;
+    insuranceFund = _insuranceFund;
 
-        require(_treasury != address(0), "ZERO_ADDRESS");
-        require(_insuranceFund != address(0), "ZERO_ADDRESS");
-        treasury = _treasury;
-        insuranceFund = _insuranceFund;
+    owner = msg.sender;
+    emit OwnerChanged(address(0), msg.sender);
 
-        owner = msg.sender;
-        emit OwnerChanged(address(0), msg.sender);
+    feeAmountTickSpacing[500] = 10; // todo: why different fee amounts for each tick spacing?
+    emit FeeAmountEnabled(500, 10);
+    feeAmountTickSpacing[3000] = 60;
+    emit FeeAmountEnabled(3000, 60);
+    feeAmountTickSpacing[10000] = 200;
+    emit FeeAmountEnabled(10000, 200);
+  }
 
-        feeAmountTickSpacing[500] = 10; // todo: why different fee amounts for each tick spacing?
-        emit FeeAmountEnabled(500, 10);
-        feeAmountTickSpacing[3000] = 60;
-        emit FeeAmountEnabled(3000, 60);
-        feeAmountTickSpacing[10000] = 200;
-        emit FeeAmountEnabled(10000, 200);
-    }
+  function setTreasury(address _treasury) external override {
+    require(_treasury != address(0), "ZERO_ADDRESS");
 
-    function setTreasury(address _treasury) external override {
-        require(_treasury != address(0), "ZERO_ADDRESS");
+    treasury = _treasury;
 
-        treasury = _treasury;
+    // emit treasury set
+  }
 
-        // emit treasury set
-    }
+  function setCalculator(address _calculator) external override {
+    require(_calculator != address(0), "ZERO_ADDRESS");
 
-    function setCalculator(address _calculator) external override {
-        require(_calculator != address(0), "ZERO_ADDRESS");
+    calculator = _calculator;
 
-        calculator = _calculator;
+    // emit calculator set
+  }
 
-        // emit calculator set
-    }
+  function setInsuranceFund(address _insuranceFund) external override {
+    require(_insuranceFund != address(0), "ZERO_ADDRESS");
 
-    function setInsuranceFund(address _insuranceFund) external override {
-        require(_insuranceFund != address(0), "ZERO_ADDRESS");
+    insuranceFund = _insuranceFund;
 
-        insuranceFund = _insuranceFund;
+    // emit insurance fund set
+  }
 
-        // emit insurance fund set
-    }
+  function createAMM(
+    address underlyingToken,
+    bytes32 rateOracleId,
+    uint256 termEndTimestamp,
+    uint24 fee
+  ) external override noDelegateCall returns (address amm) {
+    int24 tickSpacing = feeAmountTickSpacing[fee];
+    require(tickSpacing != 0);
 
-    function createAMM(
-        address underlyingToken,
-        bytes32 rateOracleId,
-        uint256 termEndTimestamp,
-        uint24 fee
-    ) external override noDelegateCall returns (address amm) {
-        int24 tickSpacing = feeAmountTickSpacing[fee]; 
-        require(tickSpacing != 0);
-        
-        uint256 termStartTimestamp = FixedAndVariableMath.blockTimestampScaled();
+    uint256 termStartTimestamp = FixedAndVariableMath.blockTimestampScaled();
 
-        require(
-            getAMMMAp[rateOracleId][underlyingToken][termStartTimestamp][termEndTimestamp][fee] ==
-                address(0)
-        );
+    require(
+      getAMMMAp[rateOracleId][underlyingToken][termStartTimestamp][
+        termEndTimestamp
+      ][fee] == address(0)
+    );
 
-        amm = deploy(
-            address(this),
-            underlyingToken,
-            rateOracleId,
-            termStartTimestamp,
-            termEndTimestamp,
-            fee,
-            tickSpacing
-        );
+    amm = deploy(
+      address(this),
+      underlyingToken,
+      rateOracleId,
+      termStartTimestamp,
+      termEndTimestamp,
+      fee,
+      tickSpacing
+    );
 
-        getAMMMAp[rateOracleId][underlyingToken][termStartTimestamp][termEndTimestamp][fee] = amm;
-        emit AMMCreated(
-            rateOracleId,
-            underlyingToken,
-            termEndTimestamp,
-            termStartTimestamp,
-            fee,
-            tickSpacing,
-            amm
-        );
-        return amm;
-    }
+    getAMMMAp[rateOracleId][underlyingToken][termStartTimestamp][
+      termEndTimestamp
+    ][fee] = amm;
+    emit AMMCreated(
+      rateOracleId,
+      underlyingToken,
+      termEndTimestamp,
+      termStartTimestamp,
+      fee,
+      tickSpacing,
+      amm
+    );
+    return amm;
+  }
 
-    function setOwner(address _owner) external override {
-        require(msg.sender == owner);
-        emit OwnerChanged(owner, _owner);
-        owner = _owner;
-    }
+  function setOwner(address _owner) external override {
+    require(msg.sender == owner);
+    emit OwnerChanged(owner, _owner);
+    owner = _owner;
+  }
 
-    // todo: don't need this since can directly set the fee proportion via the multisig
-    // function enableFeeAmount(uint24 fee, int24 tickSpacing) public override {
-    //     require(msg.sender == owner);
-    //     require(fee < 1000000); // todo: where does this amount come from?
-    //     // tick spacing is capped at 16384 to prevent the situation where tickSpacing is so large that
-    //     // TickBitmap#nextInitializedTickWithinOneWord overflows int24 container from a valid tick
-    //     // 16384 ticks represents a >5x price change with ticks of 1 bips
-    //     require(tickSpacing > 0 && tickSpacing < 16384);
-    //     require(feeAmountTickSpacing[fee] == 0);
+  // todo: don't need this since can directly set the fee proportion via the multisig
+  // function enableFeeAmount(uint24 fee, int24 tickSpacing) public override {
+  //     require(msg.sender == owner);
+  //     require(fee < 1000000); // todo: where does this amount come from?
+  //     // tick spacing is capped at 16384 to prevent the situation where tickSpacing is so large that
+  //     // TickBitmap#nextInitializedTickWithinOneWord overflows int24 container from a valid tick
+  //     // 16384 ticks represents a >5x price change with ticks of 1 bips
+  //     require(tickSpacing > 0 && tickSpacing < 16384);
+  //     require(feeAmountTickSpacing[fee] == 0);
 
-    //     feeAmountTickSpacing[fee] = tickSpacing;
-    //     emit FeeAmountEnabled(fee, tickSpacing);
-    // }
+  //     feeAmountTickSpacing[fee] = tickSpacing;
+  //     emit FeeAmountEnabled(fee, tickSpacing);
+  // }
 
+  // todo initialised, onlyGovernance
+  function addRateOracle(bytes32 _rateOracleId, address _rateOracleAddress)
+    external
+    override
+  {
+    require(_rateOracleId != bytes32(0), "ZERO_BYTES");
+    require(_rateOracleAddress != address(0), "ZERO_ADDRESS");
+    require(
+      _rateOracleId == IRateOracle(_rateOracleAddress).rateOracleId(),
+      "INVALID_ID"
+    );
+    require(getRateOracleAddress[_rateOracleId] == address(0), "EXISTED_ID");
 
-    // todo initialised, onlyGovernance
-    function addRateOracle(bytes32 _rateOracleId, address _rateOracleAddress) external override {
-        
-        require(_rateOracleId != bytes32(0), "ZERO_BYTES");
-        require(_rateOracleAddress != address(0), "ZERO_ADDRESS");
-        require(_rateOracleId == IRateOracle(_rateOracleAddress).rateOracleId(), "INVALID_ID");
-        require(getRateOracleAddress[_rateOracleId] == address(0), "EXISTED_ID");
+    getRateOracleAddress[_rateOracleId] = _rateOracleAddress;
 
-        getRateOracleAddress[_rateOracleId] = _rateOracleAddress;
-
-        // todo: emit RateOracleAdded
-    }
+    // todo: emit RateOracleAdded
+  }
 }

--- a/contracts/MarginCalculator.sol
+++ b/contracts/MarginCalculator.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "prb-math/contracts/PRBMathUD60x18Typed.sol";

--- a/contracts/MarginOracle.sol
+++ b/contracts/MarginOracle.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "./interfaces/IVoltzMarginPricer.sol";
 

--- a/contracts/core_libraries/FixedAndVariableMath.sol
+++ b/contracts/core_libraries/FixedAndVariableMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "prb-math/contracts/PRBMathSD59x18Typed.sol";
 import "prb-math/contracts/PRBMathUD60x18Typed.sol";

--- a/contracts/core_libraries/Oracle.sol
+++ b/contracts/core_libraries/Oracle.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "prb-math/contracts/PRBMathUD60x18Typed.sol";
 

--- a/contracts/core_libraries/Position.sol
+++ b/contracts/core_libraries/Position.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "../utils/FullMath.sol";
@@ -11,185 +12,162 @@ import "prb-math/contracts/PRBMathUD60x18Typed.sol";
 /// @notice Positions represent an owner address' liquidity between a lower and upper tick boundary
 /// @dev Positions store additional state for tracking fees owed to the position
 library Position {
+  using Position for Position.Info;
 
-    using Position for Position.Info;
+  // info stored for each user's position
+  struct Info {
+    uint128 liquidity;
+    int256 margin;
+    int256 fixedTokenGrowthInsideLast;
+    int256 variableTokenGrowthInsideLast;
+    int256 fixedTokenBalance;
+    int256 variableTokenBalance;
+    uint256 feeGrowthInsideLast;
+  }
 
-    // info stored for each user's position
-    struct Info {
-        uint128 liquidity;
+  /// @notice Returns the Info struct of a position, given an owner and position boundaries
+  /// @param self The mapping containing all user positions
+  /// @param owner The address of the position owner
+  /// @param tickLower The lower tick boundary of the position
+  /// @param tickUpper The upper tick boundary of the position
+  /// @return position The position info struct of the given owners' position
+  function get(
+    mapping(bytes32 => Info) storage self,
+    address owner,
+    int24 tickLower,
+    int24 tickUpper
+  ) internal view returns (Position.Info storage position) {
+    position = self[keccak256(abi.encodePacked(owner, tickLower, tickUpper))];
+  }
 
-        int256 margin;
-        int256 fixedTokenGrowthInsideLast;
-        int256 variableTokenGrowthInsideLast;
-        int256 fixedTokenBalance;
-        int256 variableTokenBalance;
+  function updateMargin(Info storage self, int256 marginDelta) internal {
+    Info memory _self = self;
+    self.margin = PRBMathSD59x18Typed
+      .add(
+        PRBMath.SD59x18({ value: _self.margin }),
+        PRBMath.SD59x18({ value: marginDelta })
+      )
+      .value;
+  }
 
-        uint256 feeGrowthInsideLast;
+  /// #if_succeeds fixedTokenBalanceDelta!=0 || variableTokenBalanceDelta!=0;
+  function updateBalances(
+    Info storage self,
+    int256 fixedTokenBalanceDelta,
+    int256 variableTokenBalanceDelta
+  ) internal {
+    // todo: turn into a require statement?
+    if (fixedTokenBalanceDelta != 0 || variableTokenBalanceDelta != 0) {
+      Info memory _self = self;
+
+      self.fixedTokenBalance = PRBMathSD59x18Typed
+        .add(
+          PRBMath.SD59x18({ value: _self.fixedTokenBalance }),
+          PRBMath.SD59x18({ value: fixedTokenBalanceDelta })
+        )
+        .value;
+
+      self.variableTokenBalance = PRBMathSD59x18Typed
+        .add(
+          PRBMath.SD59x18({ value: _self.variableTokenBalance }),
+          PRBMath.SD59x18({ value: variableTokenBalanceDelta })
+        )
+        .value;
+    }
+  }
+
+  function calculateFeeDelta(Info storage self, uint256 feeGrowthInside)
+    internal
+    pure
+    returns (uint256 _feeDelta)
+  {
+    Info memory _self = self;
+
+    require(_self.liquidity > 0, "NP");
+
+    _feeDelta = PRBMathUD60x18Typed
+      .mul(
+        PRBMathUD60x18Typed.sub(
+          PRBMath.UD60x18({ value: feeGrowthInside }),
+          PRBMath.UD60x18({ value: _self.feeGrowthInsideLast })
+        ),
+        PRBMath.UD60x18({ value: uint256(_self.liquidity) * 10**18 })
+      )
+      .value;
+  }
+
+  /// #if_succeeds fixedTokenGrowthInside==_self.fixedTokenGrowthInsideLast ==> _fixedTokenBalance == 0;
+  /// #if_succeeds variableTokenGrowthInside==_self.variableTokenGrowthInsideLast ==> _variableTokenBalance == 0;
+  /// #if_succeeds _self.liquidity > 0;
+  function calculateFixedAndVariableDelta(
+    Info storage self,
+    int256 fixedTokenGrowthInside,
+    int256 variableTokenGrowthInside
+  )
+    internal
+    pure
+    returns (int256 _fixedTokenDelta, int256 _variableTokenDelta)
+  {
+    Info memory _self = self;
+
+    require(_self.liquidity > 0, "NP");
+
+    _fixedTokenDelta = PRBMathSD59x18Typed
+      .mul(
+        PRBMathSD59x18Typed.sub(
+          PRBMath.SD59x18({ value: fixedTokenGrowthInside }),
+          PRBMath.SD59x18({ value: _self.fixedTokenGrowthInsideLast })
+        ),
+        PRBMath.SD59x18({ value: int256(uint256(_self.liquidity)) * 10**18 })
+        // PRBMath.SD59x18({value: 10**18 })
+      )
+      .value;
+
+    _variableTokenDelta = PRBMathSD59x18Typed
+      .mul(
+        PRBMathSD59x18Typed.sub(
+          PRBMath.SD59x18({ value: variableTokenGrowthInside }),
+          PRBMath.SD59x18({ value: _self.variableTokenGrowthInsideLast })
+        ),
+        PRBMath.SD59x18({ value: int256(uint256(_self.liquidity)) * 10**18 })
+        // PRBMath.SD59x18({value: 10**18 })
+      )
+      .value;
+  }
+
+  function updateFixedAndVariableTokenGrowthInside(
+    Info storage self,
+    int256 fixedTokenGrowthInside,
+    int256 variableTokenGrowthInside
+  ) internal {
+    self.fixedTokenGrowthInsideLast = fixedTokenGrowthInside;
+    self.variableTokenGrowthInsideLast = variableTokenGrowthInside;
+  }
+
+  function updateFeeGrowthInside(Info storage self, uint256 feeGrowthInside)
+    public
+  {
+    self.feeGrowthInsideLast = feeGrowthInside;
+  }
+
+  /// @notice Credits accumulated fees to a user's position
+  /// @param self The individual position to update
+  /// @param liquidityDelta The change in pool liquidity as a result of the position update
+
+  /// #if_succeeds liquidityDelta != 0;
+  function updateLiquidity(Info storage self, int128 liquidityDelta) internal {
+    Info memory _self = self;
+
+    uint128 liquidityNext;
+    if (liquidityDelta == 0) {
+      require(_self.liquidity > 0, "NP"); // disallow pokes for 0 liquidity positions
+      liquidityNext = _self.liquidity;
+    } else {
+      liquidityNext = LiquidityMath.addDelta(_self.liquidity, liquidityDelta);
     }
 
-    /// @notice Returns the Info struct of a position, given an owner and position boundaries
-    /// @param self The mapping containing all user positions
-    /// @param owner The address of the position owner
-    /// @param tickLower The lower tick boundary of the position
-    /// @param tickUpper The upper tick boundary of the position
-    /// @return position The position info struct of the given owners' position
-    function get(
-        mapping(bytes32 => Info) storage self,
-        address owner,
-        int24 tickLower,
-        int24 tickUpper
-    ) internal view returns (Position.Info storage position) {
-        position = self[
-            keccak256(abi.encodePacked(owner, tickLower, tickUpper))
-        ];
-    }
-
-
-    function updateMargin(Info storage self, int256 marginDelta) internal {
-        Info memory _self = self;
-        self.margin = PRBMathSD59x18Typed
-            .add(
-                PRBMath.SD59x18({value: _self.margin}),
-                PRBMath.SD59x18({value: marginDelta})
-            )
-            .value;
-    }
-
-    
-    /// #if_succeeds fixedTokenBalanceDelta!=0 || variableTokenBalanceDelta!=0;
-    function updateBalances(
-        Info storage self,
-        int256 fixedTokenBalanceDelta,
-        int256 variableTokenBalanceDelta
-    ) internal {
-
-        // todo: turn into a require statement?
-        if (fixedTokenBalanceDelta != 0 || variableTokenBalanceDelta != 0) {
-
-            Info memory _self = self;
-             
-            self.fixedTokenBalance = PRBMathSD59x18Typed
-                .add(
-                    PRBMath.SD59x18({value: _self.fixedTokenBalance}),
-                    PRBMath.SD59x18({value: fixedTokenBalanceDelta})
-                )
-                .value;
-
-            self.variableTokenBalance = PRBMathSD59x18Typed
-                .add(
-                    PRBMath.SD59x18({value: _self.variableTokenBalance}),
-                    PRBMath.SD59x18({value: variableTokenBalanceDelta})
-                )
-                .value;
-        }
-
-    }
-
-
-    
-    function calculateFeeDelta(
-        Info storage self,
-        uint256 feeGrowthInside
-    ) internal pure returns (uint256 _feeDelta) {
-        
-        Info memory _self = self;
-
-        require(_self.liquidity > 0, "NP");
-
-        _feeDelta = PRBMathUD60x18Typed
-            .mul(
-                PRBMathUD60x18Typed.sub(
-                    PRBMath.UD60x18({value: feeGrowthInside}),
-                    PRBMath.UD60x18({value: _self.feeGrowthInsideLast})
-                ),
-                PRBMath.UD60x18({value: uint256(_self.liquidity) * 10**18 })
-            )
-            .value;
-    }
-    
-    
-    /// #if_succeeds fixedTokenGrowthInside==_self.fixedTokenGrowthInsideLast ==> _fixedTokenBalance == 0;
-    /// #if_succeeds variableTokenGrowthInside==_self.variableTokenGrowthInsideLast ==> _variableTokenBalance == 0;
-    /// #if_succeeds _self.liquidity > 0;
-    function calculateFixedAndVariableDelta(
-        Info storage self,
-        int256 fixedTokenGrowthInside,
-        int256 variableTokenGrowthInside
-    ) internal pure returns(int256 _fixedTokenDelta, int256 _variableTokenDelta) {
-
-        Info memory _self = self;
-
-        require(_self.liquidity > 0, "NP");
-
-        _fixedTokenDelta = PRBMathSD59x18Typed
-            .mul(
-                PRBMathSD59x18Typed.sub(
-                    PRBMath.SD59x18({value: fixedTokenGrowthInside}),
-                    PRBMath.SD59x18({value: _self.fixedTokenGrowthInsideLast})
-                ),
-                PRBMath.SD59x18({value: int256(uint256(_self.liquidity)) * 10**18 })
-                // PRBMath.SD59x18({value: 10**18 })
-            )
-            .value;
-
-        _variableTokenDelta = PRBMathSD59x18Typed
-            .mul(
-                PRBMathSD59x18Typed.sub(
-                    PRBMath.SD59x18({value: variableTokenGrowthInside}),
-                    PRBMath.SD59x18({
-                        value: _self.variableTokenGrowthInsideLast
-                    })
-                ),
-                PRBMath.SD59x18({value: int256(uint256(_self.liquidity)) * 10**18 })
-                // PRBMath.SD59x18({value: 10**18 })
-            )
-            .value;
-
-    }
-    
-    function updateFixedAndVariableTokenGrowthInside(
-        Info storage self,
-        int256 fixedTokenGrowthInside,
-        int256 variableTokenGrowthInside
-    ) internal {
-
-        self.fixedTokenGrowthInsideLast = fixedTokenGrowthInside;
-        self.variableTokenGrowthInsideLast = variableTokenGrowthInside;
-
-    }
-
-    function updateFeeGrowthInside(
-        Info storage self,
-        uint256 feeGrowthInside
-    ) public {
-
-        self.feeGrowthInsideLast = feeGrowthInside;
-
-    }
-
-    /// @notice Credits accumulated fees to a user's position
-    /// @param self The individual position to update
-    /// @param liquidityDelta The change in pool liquidity as a result of the position update
-
-    /// #if_succeeds liquidityDelta != 0;
-    function updateLiquidity(Info storage self, int128 liquidityDelta)
-        internal
-    {
-        Info memory _self = self;
-
-        uint128 liquidityNext;
-        if (liquidityDelta == 0) {
-            require(_self.liquidity > 0, "NP"); // disallow pokes for 0 liquidity positions
-            liquidityNext = _self.liquidity;
-        } else {
-            liquidityNext = LiquidityMath.addDelta(
-                _self.liquidity,
-                liquidityDelta
-            );
-        }
-
-        // update the position
-        // todo: have a timestamp that check when was the last time the position was updated and avoids the update cost
-        if (liquidityDelta != 0) self.liquidity = liquidityNext;
-    }
+    // update the position
+    // todo: have a timestamp that check when was the last time the position was updated and avoids the update cost
+    if (liquidityDelta != 0) self.liquidity = liquidityNext;
+  }
 }

--- a/contracts/core_libraries/SwapMath.sol
+++ b/contracts/core_libraries/SwapMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "../utils/FullMath.sol";

--- a/contracts/core_libraries/Tick.sol
+++ b/contracts/core_libraries/Tick.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "../utils/LowGasSafeMath.sol";
@@ -12,304 +13,290 @@ import "prb-math/contracts/PRBMathSD59x18Typed.sol";
 /// @title Tick
 /// @notice Contains functions for managing tick processes and relevant calculations
 library Tick {
-    using LowGasSafeMath for int256;
-    using SafeCast for int256;
+  using LowGasSafeMath for int256;
+  using SafeCast for int256;
 
-    // info stored for each initialized individual tick
-    struct Info {
-        // the total position liquidity that references this tick
-        uint128 liquidityGross;
-        // amount of net liquidity added (subtracted) when tick is crossed from left to right (right to left),
-        int128 liquidityNet;
-        // fee growth per unit of liquidity on the _other_ side of this tick (relative to the current tick)
-        // only has relative meaning, not absolute — the value depends on when the tick is initialized
+  // info stored for each initialized individual tick
+  struct Info {
+    // the total position liquidity that references this tick
+    uint128 liquidityGross;
+    // amount of net liquidity added (subtracted) when tick is crossed from left to right (right to left),
+    int128 liquidityNet;
+    // fee growth per unit of liquidity on the _other_ side of this tick (relative to the current tick)
+    // only has relative meaning, not absolute — the value depends on when the tick is initialized
 
-        int256 fixedTokenGrowthOutside;
-        int256 variableTokenGrowthOutside;
+    int256 fixedTokenGrowthOutside;
+    int256 variableTokenGrowthOutside;
+    uint256 feeGrowthOutside;
+    bool initialized;
+  }
 
-        uint256 feeGrowthOutside;
+  function getFeeGrowthInside(
+    mapping(int24 => Tick.Info) storage self,
+    int24 tickLower,
+    int24 tickUpper,
+    int24 tickCurrent,
+    uint256 feeGrowthGlobal
+  ) internal view returns (uint256 feeGrowthInside) {
+    Info storage lower = self[tickLower];
+    Info storage upper = self[tickUpper];
 
-        bool initialized;
+    // calculate fee growth below
+    uint256 feeGrowthBelow;
+
+    if (tickCurrent >= tickLower) {
+      feeGrowthBelow = lower.feeGrowthOutside;
+    } else {
+      feeGrowthBelow = PRBMathUD60x18Typed
+        .sub(
+          PRBMath.UD60x18({ value: feeGrowthGlobal }),
+          PRBMath.UD60x18({ value: lower.feeGrowthOutside })
+        )
+        .value;
     }
 
+    // calculate fee growth above
+    uint256 feeGrowthAbove;
 
-    function getFeeGrowthInside(
-        mapping(int24 => Tick.Info) storage self,
-        int24 tickLower,
-        int24 tickUpper,
-        int24 tickCurrent,
-        uint256 feeGrowthGlobal
-    ) internal view returns (uint256 feeGrowthInside) {
-        Info storage lower = self[tickLower];
-        Info storage upper = self[tickUpper];
-
-        // calculate fee growth below
-        uint256 feeGrowthBelow;
-
-        if (tickCurrent >= tickLower) {
-            feeGrowthBelow = lower.feeGrowthOutside;
-        } else {
-            feeGrowthBelow = PRBMathUD60x18Typed.sub(
-
-                PRBMath.UD60x18({
-                    value: feeGrowthGlobal
-                }),
-
-                PRBMath.UD60x18({
-                    value: lower.feeGrowthOutside
-                })
-
-            ).value;
-        }
-
-        // calculate fee growth above
-        uint256 feeGrowthAbove;
-
-        if (tickCurrent < tickUpper) {
-            feeGrowthAbove = upper.feeGrowthOutside;
-        } else {
-            feeGrowthAbove = PRBMathUD60x18Typed.sub(
-
-                PRBMath.UD60x18({
-                    value: feeGrowthGlobal
-                }),
-
-                PRBMath.UD60x18({
-                    value: upper.feeGrowthOutside
-                })
-
-            ).value;
-        }
-
-        feeGrowthInside = PRBMathUD60x18Typed
-            .sub(
-                PRBMath.UD60x18({value: feeGrowthGlobal}),
-                PRBMathUD60x18Typed.add(
-                    PRBMath.UD60x18({value: feeGrowthBelow}),
-                    PRBMath.UD60x18({value: feeGrowthAbove})
-                )
-            ).value;
-
-    }
-    
-    
-    /// @notice Derives max liquidity per tick from given tick spacing
-    /// @dev Executed within the pool constructor
-    /// @param tickSpacing The amount of required tick separation, realized in multiples of `tickSpacing`
-    ///     e.g., a tickSpacing of 3 requires ticks to be initialized every 3rd tick i.e., ..., -6, -3, 0, 3, 6, ...
-    /// @return The max liquidity per tick
-    function tickSpacingToMaxLiquidityPerTick(int24 tickSpacing)
-        internal
-        pure
-        returns (uint128)
-    {
-        int24 minTick = (TickMath.MIN_TICK / tickSpacing) * tickSpacing;
-        int24 maxTick = (TickMath.MAX_TICK / tickSpacing) * tickSpacing;
-        uint24 numTicks = uint24((maxTick - minTick) / tickSpacing) + 1;
-        return type(uint128).max / numTicks;
+    if (tickCurrent < tickUpper) {
+      feeGrowthAbove = upper.feeGrowthOutside;
+    } else {
+      feeGrowthAbove = PRBMathUD60x18Typed
+        .sub(
+          PRBMath.UD60x18({ value: feeGrowthGlobal }),
+          PRBMath.UD60x18({ value: upper.feeGrowthOutside })
+        )
+        .value;
     }
 
-    struct VariableTokenGrowthInsideParams {
-        int24 tickLower;
-        int24 tickUpper;
-        int24 tickCurrent;
-        int256 variableTokenGrowthGlobal;
+    feeGrowthInside = PRBMathUD60x18Typed
+      .sub(
+        PRBMath.UD60x18({ value: feeGrowthGlobal }),
+        PRBMathUD60x18Typed.add(
+          PRBMath.UD60x18({ value: feeGrowthBelow }),
+          PRBMath.UD60x18({ value: feeGrowthAbove })
+        )
+      )
+      .value;
+  }
+
+  /// @notice Derives max liquidity per tick from given tick spacing
+  /// @dev Executed within the pool constructor
+  /// @param tickSpacing The amount of required tick separation, realized in multiples of `tickSpacing`
+  ///     e.g., a tickSpacing of 3 requires ticks to be initialized every 3rd tick i.e., ..., -6, -3, 0, 3, 6, ...
+  /// @return The max liquidity per tick
+  function tickSpacingToMaxLiquidityPerTick(int24 tickSpacing)
+    internal
+    pure
+    returns (uint128)
+  {
+    int24 minTick = (TickMath.MIN_TICK / tickSpacing) * tickSpacing;
+    int24 maxTick = (TickMath.MAX_TICK / tickSpacing) * tickSpacing;
+    uint24 numTicks = uint24((maxTick - minTick) / tickSpacing) + 1;
+    return type(uint128).max / numTicks;
+  }
+
+  struct VariableTokenGrowthInsideParams {
+    int24 tickLower;
+    int24 tickUpper;
+    int24 tickCurrent;
+    int256 variableTokenGrowthGlobal;
+  }
+
+  function getVariableTokenGrowthInside(
+    mapping(int24 => Tick.Info) storage self,
+    VariableTokenGrowthInsideParams memory params
+  ) public view returns (int256 variableTokenGrowthInside) {
+    Info storage lower = self[params.tickLower];
+    Info storage upper = self[params.tickUpper];
+
+    // calculate the VariableTokenGrowth below
+    int256 variableTokenGrowthBelow;
+
+    if (params.tickCurrent >= params.tickLower) {
+      variableTokenGrowthBelow = lower.variableTokenGrowthOutside;
+    } else {
+      variableTokenGrowthBelow = PRBMathSD59x18Typed
+        .sub(
+          PRBMath.SD59x18({ value: params.variableTokenGrowthGlobal }),
+          PRBMath.SD59x18({ value: lower.variableTokenGrowthOutside })
+        )
+        .value;
     }
 
-    function getVariableTokenGrowthInside(
-        mapping(int24 => Tick.Info) storage self,
-        VariableTokenGrowthInsideParams memory params
-    ) public view returns (int256 variableTokenGrowthInside) {
-        Info storage lower = self[params.tickLower];
-        Info storage upper = self[params.tickUpper];
+    // calculate the VariableTokenGrowth above
+    int256 variableTokenGrowthAbove;
 
-        // calculate the VariableTokenGrowth below
-        int256 variableTokenGrowthBelow;
-
-        if (params.tickCurrent >= params.tickLower) {
-            variableTokenGrowthBelow = lower.variableTokenGrowthOutside;
-        } else {
-            variableTokenGrowthBelow = PRBMathSD59x18Typed
-                .sub(
-                    PRBMath.SD59x18({value: params.variableTokenGrowthGlobal}),
-                    PRBMath.SD59x18({value: lower.variableTokenGrowthOutside})
-                )
-                .value;
-        }
-
-        // calculate the VariableTokenGrowth above
-        int256 variableTokenGrowthAbove;
-
-        if (params.tickCurrent < params.tickUpper) {
-            variableTokenGrowthAbove = upper.variableTokenGrowthOutside;
-        } else {
-            variableTokenGrowthAbove = PRBMathSD59x18Typed
-                .sub(
-                    PRBMath.SD59x18({value: params.variableTokenGrowthGlobal}),
-                    PRBMath.SD59x18({value: upper.variableTokenGrowthOutside})
-                )
-                .value;
-        }
-
-        variableTokenGrowthInside = PRBMathSD59x18Typed
-            .sub(
-                PRBMath.SD59x18({value: params.variableTokenGrowthGlobal}),
-                PRBMathSD59x18Typed.add(
-                    PRBMath.SD59x18({value: variableTokenGrowthBelow}),
-                    PRBMath.SD59x18({value: variableTokenGrowthAbove})
-                )
-            )
-            .value;
+    if (params.tickCurrent < params.tickUpper) {
+      variableTokenGrowthAbove = upper.variableTokenGrowthOutside;
+    } else {
+      variableTokenGrowthAbove = PRBMathSD59x18Typed
+        .sub(
+          PRBMath.SD59x18({ value: params.variableTokenGrowthGlobal }),
+          PRBMath.SD59x18({ value: upper.variableTokenGrowthOutside })
+        )
+        .value;
     }
 
-    struct FixedTokenGrowthInsideParams {
-        int24 tickLower;
-        int24 tickUpper;
-        int24 tickCurrent;
-        int256 fixedTokenGrowthGlobal;
+    variableTokenGrowthInside = PRBMathSD59x18Typed
+      .sub(
+        PRBMath.SD59x18({ value: params.variableTokenGrowthGlobal }),
+        PRBMathSD59x18Typed.add(
+          PRBMath.SD59x18({ value: variableTokenGrowthBelow }),
+          PRBMath.SD59x18({ value: variableTokenGrowthAbove })
+        )
+      )
+      .value;
+  }
+
+  struct FixedTokenGrowthInsideParams {
+    int24 tickLower;
+    int24 tickUpper;
+    int24 tickCurrent;
+    int256 fixedTokenGrowthGlobal;
+  }
+
+  function getFixedTokenGrowthInside(
+    mapping(int24 => Tick.Info) storage self,
+    FixedTokenGrowthInsideParams memory params
+  ) public view returns (int256 fixedTokenGrowthInside) {
+    Info storage lower = self[params.tickLower];
+    Info storage upper = self[params.tickUpper];
+
+    // calculate the FixedTokenGrowth below
+    int256 fixedTokenGrowthBelow;
+
+    if (params.tickCurrent >= params.tickLower) {
+      fixedTokenGrowthBelow = lower.fixedTokenGrowthOutside;
+    } else {
+      fixedTokenGrowthBelow = PRBMathSD59x18Typed
+        .sub(
+          PRBMath.SD59x18({ value: params.fixedTokenGrowthGlobal }),
+          PRBMath.SD59x18({ value: lower.fixedTokenGrowthOutside })
+        )
+        .value;
     }
 
-    function getFixedTokenGrowthInside(
-        mapping(int24 => Tick.Info) storage self,
-        FixedTokenGrowthInsideParams memory params
-    ) public view returns (int256 fixedTokenGrowthInside) {
-        Info storage lower = self[params.tickLower];
-        Info storage upper = self[params.tickUpper];
+    // calculate the FixedTokenGrowth above
+    int256 fixedTokenGrowthAbove;
 
-        // calculate the FixedTokenGrowth below
-        int256 fixedTokenGrowthBelow;
-
-        if (params.tickCurrent >= params.tickLower) {
-            fixedTokenGrowthBelow = lower.fixedTokenGrowthOutside;
-        } else {
-            fixedTokenGrowthBelow = PRBMathSD59x18Typed
-                .sub(
-                    PRBMath.SD59x18({value: params.fixedTokenGrowthGlobal}),
-                    PRBMath.SD59x18({value: lower.fixedTokenGrowthOutside})
-                )
-                .value;
-        }
-
-        // calculate the FixedTokenGrowth above
-        int256 fixedTokenGrowthAbove;
-
-        if (params.tickCurrent < params.tickUpper) {
-            fixedTokenGrowthAbove = upper.fixedTokenGrowthOutside;
-        } else {
-            fixedTokenGrowthAbove = PRBMathSD59x18Typed
-                .sub(
-                    PRBMath.SD59x18({value: params.fixedTokenGrowthGlobal}),
-                    PRBMath.SD59x18({value: upper.fixedTokenGrowthOutside})
-                )
-                .value;
-        }
-
-        fixedTokenGrowthInside = PRBMathSD59x18Typed
-            .sub(
-                PRBMath.SD59x18({value: params.fixedTokenGrowthGlobal}),
-                PRBMathSD59x18Typed.add(
-                    PRBMath.SD59x18({value: fixedTokenGrowthBelow}),
-                    PRBMath.SD59x18({value: fixedTokenGrowthAbove})
-                )
-            )
-            .value;
+    if (params.tickCurrent < params.tickUpper) {
+      fixedTokenGrowthAbove = upper.fixedTokenGrowthOutside;
+    } else {
+      fixedTokenGrowthAbove = PRBMathSD59x18Typed
+        .sub(
+          PRBMath.SD59x18({ value: params.fixedTokenGrowthGlobal }),
+          PRBMath.SD59x18({ value: upper.fixedTokenGrowthOutside })
+        )
+        .value;
     }
 
-    /// @notice Updates a tick and returns true if the tick was flipped from initialized to uninitialized, or vice versa
-    /// @param self The mapping containing all tick information for initialized ticks
-    /// @param tick The tick that will be updated
-    /// @param tickCurrent The current tick
-    /// @param liquidityDelta A new amount of liquidity to be added (subtracted) when tick is crossed from left to right (right to left)
-    /// @param upper true for updating a position's upper tick, or false for updating a position's lower tick
-    /// @param maxLiquidity The maximum liquidity allocation for a single tick
-    /// @return flipped Whether the tick was flipped from initialized to uninitialized, or vice versa
-    function update(
-        mapping(int24 => Tick.Info) storage self,
-        int24 tick,
-        int24 tickCurrent,
-        int128 liquidityDelta,
-        int256 fixedTokenGrowthGlobal,
-        int256 variableTokenGrowthGlobal,
-        uint256 feeGrowthGlobal,
-        bool upper,
-        uint128 maxLiquidity
-    ) internal returns (bool flipped) {
-        Tick.Info storage info = self[tick];
+    fixedTokenGrowthInside = PRBMathSD59x18Typed
+      .sub(
+        PRBMath.SD59x18({ value: params.fixedTokenGrowthGlobal }),
+        PRBMathSD59x18Typed.add(
+          PRBMath.SD59x18({ value: fixedTokenGrowthBelow }),
+          PRBMath.SD59x18({ value: fixedTokenGrowthAbove })
+        )
+      )
+      .value;
+  }
 
-        uint128 liquidityGrossBefore = info.liquidityGross;
-        uint128 liquidityGrossAfter = LiquidityMath.addDelta(
-            liquidityGrossBefore,
-            liquidityDelta
-        );
+  /// @notice Updates a tick and returns true if the tick was flipped from initialized to uninitialized, or vice versa
+  /// @param self The mapping containing all tick information for initialized ticks
+  /// @param tick The tick that will be updated
+  /// @param tickCurrent The current tick
+  /// @param liquidityDelta A new amount of liquidity to be added (subtracted) when tick is crossed from left to right (right to left)
+  /// @param upper true for updating a position's upper tick, or false for updating a position's lower tick
+  /// @param maxLiquidity The maximum liquidity allocation for a single tick
+  /// @return flipped Whether the tick was flipped from initialized to uninitialized, or vice versa
+  function update(
+    mapping(int24 => Tick.Info) storage self,
+    int24 tick,
+    int24 tickCurrent,
+    int128 liquidityDelta,
+    int256 fixedTokenGrowthGlobal,
+    int256 variableTokenGrowthGlobal,
+    uint256 feeGrowthGlobal,
+    bool upper,
+    uint128 maxLiquidity
+  ) internal returns (bool flipped) {
+    Tick.Info storage info = self[tick];
 
-        require(liquidityGrossAfter <= maxLiquidity, "LO");
+    uint128 liquidityGrossBefore = info.liquidityGross;
+    uint128 liquidityGrossAfter = LiquidityMath.addDelta(
+      liquidityGrossBefore,
+      liquidityDelta
+    );
 
-        flipped = (liquidityGrossAfter == 0) != (liquidityGrossBefore == 0);
+    require(liquidityGrossAfter <= maxLiquidity, "LO");
 
-        if (liquidityGrossBefore == 0) {
-            // by convention, we assume that all growth before a tick was initialized happened _below_ the tick
-            if (tick <= tickCurrent) {
-                info.feeGrowthOutside = feeGrowthGlobal;
+    flipped = (liquidityGrossAfter == 0) != (liquidityGrossBefore == 0);
 
-                info.fixedTokenGrowthOutside = fixedTokenGrowthGlobal;
+    if (liquidityGrossBefore == 0) {
+      // by convention, we assume that all growth before a tick was initialized happened _below_ the tick
+      if (tick <= tickCurrent) {
+        info.feeGrowthOutside = feeGrowthGlobal;
 
-                info.variableTokenGrowthOutside = variableTokenGrowthGlobal;
-            }
+        info.fixedTokenGrowthOutside = fixedTokenGrowthGlobal;
 
-            info.initialized = true;
-        }
+        info.variableTokenGrowthOutside = variableTokenGrowthGlobal;
+      }
 
-        info.liquidityGross = liquidityGrossAfter;
-
-        // when the lower (upper) tick is crossed left to right (right to left), liquidity must be added (removed)
-        info.liquidityNet = upper
-            ? int256(info.liquidityNet).sub(liquidityDelta).toInt128()
-            : int256(info.liquidityNet).add(liquidityDelta).toInt128();
+      info.initialized = true;
     }
 
-    /// @notice Clears tick data
-    /// @param self The mapping containing all initialized tick information for initialized ticks
-    /// @param tick The tick that will be cleared
-    function clear(mapping(int24 => Tick.Info) storage self, int24 tick)
-        internal
-    {
-        delete self[tick];
-    }
+    info.liquidityGross = liquidityGrossAfter;
 
-    /// @notice Transitions to next tick as needed by price movement
-    /// @param self The mapping containing all tick information for initialized ticks
-    /// @param tick The destination tick of the transition
-    /// @return liquidityNet The amount of liquidity added (subtracted) when tick is crossed from left to right (right to left)
-    function cross(
-        mapping(int24 => Tick.Info) storage self,
-        int24 tick,
-        int256 fixedTokenGrowthGlobal,
-        int256 variableTokenGrowthGlobal,
-        uint256 feeGrowthGlobal
-    ) internal returns (int128 liquidityNet) {
-        Tick.Info storage info = self[tick];
+    // when the lower (upper) tick is crossed left to right (right to left), liquidity must be added (removed)
+    info.liquidityNet = upper
+      ? int256(info.liquidityNet).sub(liquidityDelta).toInt128()
+      : int256(info.liquidityNet).add(liquidityDelta).toInt128();
+  }
 
-        info.feeGrowthOutside = PRBMathUD60x18Typed
-            .sub(
-                PRBMath.UD60x18({value: feeGrowthGlobal}),
-                PRBMath.UD60x18({value: info.feeGrowthOutside})
-            )
-            .value;
+  /// @notice Clears tick data
+  /// @param self The mapping containing all initialized tick information for initialized ticks
+  /// @param tick The tick that will be cleared
+  function clear(mapping(int24 => Tick.Info) storage self, int24 tick)
+    internal
+  {
+    delete self[tick];
+  }
 
-        info.fixedTokenGrowthOutside = PRBMathSD59x18Typed
-            .sub(
-                PRBMath.SD59x18({value: fixedTokenGrowthGlobal}),
-                PRBMath.SD59x18({value: info.fixedTokenGrowthOutside})
-            )
-            .value;
+  /// @notice Transitions to next tick as needed by price movement
+  /// @param self The mapping containing all tick information for initialized ticks
+  /// @param tick The destination tick of the transition
+  /// @return liquidityNet The amount of liquidity added (subtracted) when tick is crossed from left to right (right to left)
+  function cross(
+    mapping(int24 => Tick.Info) storage self,
+    int24 tick,
+    int256 fixedTokenGrowthGlobal,
+    int256 variableTokenGrowthGlobal,
+    uint256 feeGrowthGlobal
+  ) internal returns (int128 liquidityNet) {
+    Tick.Info storage info = self[tick];
 
-        info.variableTokenGrowthOutside = PRBMathSD59x18Typed
-            .sub(
-                PRBMath.SD59x18({value: variableTokenGrowthGlobal}),
-                PRBMath.SD59x18({value: info.variableTokenGrowthOutside})
-            )
-            .value;
+    info.feeGrowthOutside = PRBMathUD60x18Typed
+      .sub(
+        PRBMath.UD60x18({ value: feeGrowthGlobal }),
+        PRBMath.UD60x18({ value: info.feeGrowthOutside })
+      )
+      .value;
 
-        liquidityNet = info.liquidityNet;
-    }
+    info.fixedTokenGrowthOutside = PRBMathSD59x18Typed
+      .sub(
+        PRBMath.SD59x18({ value: fixedTokenGrowthGlobal }),
+        PRBMath.SD59x18({ value: info.fixedTokenGrowthOutside })
+      )
+      .value;
+
+    info.variableTokenGrowthOutside = PRBMathSD59x18Typed
+      .sub(
+        PRBMath.SD59x18({ value: variableTokenGrowthGlobal }),
+        PRBMath.SD59x18({ value: info.variableTokenGrowthOutside })
+      )
+      .value;
+
+    liquidityNet = info.liquidityNet;
+  }
 }

--- a/contracts/core_libraries/TickBitmap.sol
+++ b/contracts/core_libraries/TickBitmap.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "../utils/BitMath.sol";
@@ -7,84 +8,82 @@ import "../utils/BitMath.sol";
 /// @notice Stores a packed mapping of tick index to its initialized state
 /// @dev The mapping uses int16 for keys since ticks are represented as int24 and there are 256 (2^8) values per word.
 library TickBitmap {
-    /// @notice Computes the position in the mapping where the initialized bit for a tick lives
-    /// @param tick The tick for which to compute the position
-    /// @return wordPos The key in the mapping containing the word in which the bit is stored
-    /// @return bitPos The bit position in the word where the flag is stored
-    function position(int24 tick)
-        private
-        pure
-        returns (int16 wordPos, uint8 bitPos)
-    {
-        wordPos = int16(tick >> 8);
-        bitPos = uint8(int8(tick % 256)); //todo: resolve this issue, might be new solidity version issue
+  /// @notice Computes the position in the mapping where the initialized bit for a tick lives
+  /// @param tick The tick for which to compute the position
+  /// @return wordPos The key in the mapping containing the word in which the bit is stored
+  /// @return bitPos The bit position in the word where the flag is stored
+  function position(int24 tick)
+    private
+    pure
+    returns (int16 wordPos, uint8 bitPos)
+  {
+    wordPos = int16(tick >> 8);
+    bitPos = uint8(int8(tick % 256)); //todo: resolve this issue, might be new solidity version issue
+  }
+
+  /// @notice Flips the initialized state for a given tick from false to true, or vice versa
+  /// @param self The mapping in which to flip the tick
+  /// @param tick The tick to flip
+  /// @param tickSpacing The spacing between usable ticks
+  function flipTick(
+    mapping(int16 => uint256) storage self,
+    int24 tick,
+    int24 tickSpacing
+  ) internal {
+    require(tick % tickSpacing == 0); // ensure that the tick is spaced
+    (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
+    uint256 mask = 1 << bitPos;
+    self[wordPos] ^= mask;
+  }
+
+  /// @notice Returns the next initialized tick contained in the same word (or adjacent word) as the tick that is either
+  /// to the left (less than or equal to) or right (greater than) of the given tick
+  /// @param self The mapping in which to compute the next initialized tick
+  /// @param tick The starting tick
+  /// @param tickSpacing The spacing between usable ticks
+  /// @param lte Whether to search for the next initialized tick to the left (less than or equal to the starting tick)
+  /// @return next The next initialized or uninitialized tick up to 256 ticks away from the current tick
+  /// @return initialized Whether the next tick is initialized, as the function only searches within up to 256 ticks
+  function nextInitializedTickWithinOneWord(
+    mapping(int16 => uint256) storage self,
+    int24 tick,
+    int24 tickSpacing,
+    bool lte
+  ) internal view returns (int24 next, bool initialized) {
+    int24 compressed = tick / tickSpacing;
+    if (tick < 0 && tick % tickSpacing != 0) compressed--; // round towards negative infinity
+
+    if (lte) {
+      (int16 wordPos, uint8 bitPos) = position(compressed);
+      // all the 1s at or to the right of the current bitPos
+      uint256 mask = (1 << bitPos) - 1 + (1 << bitPos);
+      uint256 masked = self[wordPos] & mask;
+
+      // if there are no initialized ticks to the right of or at the current tick, return rightmost in the word
+      initialized = masked != 0;
+      // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+      next = initialized
+        ? (compressed -
+          int24(uint24(bitPos - BitMath.mostSignificantBit(masked)))) *
+          tickSpacing
+        : (compressed - int24(uint24(bitPos))) * tickSpacing;
+    } else {
+      // start from the word of the next tick, since the current tick state doesn't matter
+      (int16 wordPos, uint8 bitPos) = position(compressed + 1);
+      // all the 1s at or to the left of the bitPos
+      uint256 mask = ~((1 << bitPos) - 1);
+      uint256 masked = self[wordPos] & mask;
+
+      // if there are no initialized ticks to the left of the current tick, return leftmost in the word
+      initialized = masked != 0;
+      // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
+      next = initialized
+        ? (compressed +
+          1 +
+          int24(uint24(BitMath.leastSignificantBit(masked) - bitPos))) *
+          tickSpacing
+        : (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) *
+          tickSpacing;
     }
-
-    /// @notice Flips the initialized state for a given tick from false to true, or vice versa
-    /// @param self The mapping in which to flip the tick
-    /// @param tick The tick to flip
-    /// @param tickSpacing The spacing between usable ticks
-    function flipTick(
-        mapping(int16 => uint256) storage self,
-        int24 tick,
-        int24 tickSpacing
-    ) internal {
-        require(tick % tickSpacing == 0); // ensure that the tick is spaced
-        (int16 wordPos, uint8 bitPos) = position(tick / tickSpacing);
-        uint256 mask = 1 << bitPos;
-        self[wordPos] ^= mask;
-    }
-
-    /// @notice Returns the next initialized tick contained in the same word (or adjacent word) as the tick that is either
-    /// to the left (less than or equal to) or right (greater than) of the given tick
-    /// @param self The mapping in which to compute the next initialized tick
-    /// @param tick The starting tick
-    /// @param tickSpacing The spacing between usable ticks
-    /// @param lte Whether to search for the next initialized tick to the left (less than or equal to the starting tick)
-    /// @return next The next initialized or uninitialized tick up to 256 ticks away from the current tick
-    /// @return initialized Whether the next tick is initialized, as the function only searches within up to 256 ticks
-    function nextInitializedTickWithinOneWord(
-        mapping(int16 => uint256) storage self,
-        int24 tick,
-        int24 tickSpacing,
-        bool lte
-    ) internal view returns (int24 next, bool initialized) {
-        int24 compressed = tick / tickSpacing;
-        if (tick < 0 && tick % tickSpacing != 0) compressed--; // round towards negative infinity
-
-        if (lte) {
-            (int16 wordPos, uint8 bitPos) = position(compressed);
-            // all the 1s at or to the right of the current bitPos
-            uint256 mask = (1 << bitPos) - 1 + (1 << bitPos);
-            uint256 masked = self[wordPos] & mask;
-
-            // if there are no initialized ticks to the right of or at the current tick, return rightmost in the word
-            initialized = masked != 0;
-            // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
-            next = initialized
-                ? (compressed -
-                    int24(
-                        uint24(bitPos - BitMath.mostSignificantBit(masked))
-                    )) * tickSpacing
-                : (compressed - int24(uint24(bitPos))) * tickSpacing;
-        } else {
-            // start from the word of the next tick, since the current tick state doesn't matter
-            (int16 wordPos, uint8 bitPos) = position(compressed + 1);
-            // all the 1s at or to the left of the bitPos
-            uint256 mask = ~((1 << bitPos) - 1);
-            uint256 masked = self[wordPos] & mask;
-
-            // if there are no initialized ticks to the left of the current tick, return leftmost in the word
-            initialized = masked != 0;
-            // overflow/underflow is possible, but prevented externally by limiting both tickSpacing and tick
-            next = initialized
-                ? (compressed +
-                    1 +
-                    int24(
-                        uint24(BitMath.leastSignificantBit(masked) - bitPos)
-                    )) * tickSpacing
-                : (compressed + 1 + int24(uint24(type(uint8).max - bitPos))) *
-                    tickSpacing;
-        }
-    }
+  }
 }

--- a/contracts/core_libraries/Trader.sol
+++ b/contracts/core_libraries/Trader.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "prb-math/contracts/PRBMathSD59x18Typed.sol";
 import "../MarginCalculator.sol";

--- a/contracts/interfaces/IAMM.sol
+++ b/contracts/interfaces/IAMM.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "./amm/IAMMImmutables.sol";

--- a/contracts/interfaces/IAMMDeployer.sol
+++ b/contracts/interfaces/IAMMDeployer.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title An interface for a contract that is capable of deploying Voltz AMMs

--- a/contracts/interfaces/IAMMFactory.sol
+++ b/contracts/interfaces/IAMMFactory.sol
@@ -1,91 +1,95 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 pragma solidity ^0.8.0;
 
 /// @title The interface for the Voltz AMM Factory
 /// @notice The AMM Factory facilitates creation of Voltz AMMs and control over the protocol fees
 interface IAMMFactory {
-    /// @notice Emitted when the owner of the factory is changed
-    /// @param oldOwner The owner before the owner was changed
-    /// @param newOwner The owner after the owner was changed
-    event OwnerChanged(address indexed oldOwner, address indexed newOwner);
+  /// @notice Emitted when the owner of the factory is changed
+  /// @param oldOwner The owner before the owner was changed
+  /// @param newOwner The owner after the owner was changed
+  event OwnerChanged(address indexed oldOwner, address indexed newOwner);
 
-    /// @notice Emitted when a amm is created
-    event AMMCreated(
-        bytes32 indexed rateOracleId,
-        address indexed underlyingToken,
-        uint256 indexed termStartTimestamp,
-        uint256 termEndTimestamp,
-        uint24 fee,
-        int24 tickSpacing,
-        address amm
-    );
+  /// @notice Emitted when a amm is created
+  event AMMCreated(
+    bytes32 indexed rateOracleId,
+    address indexed underlyingToken,
+    uint256 indexed termStartTimestamp,
+    uint256 termEndTimestamp,
+    uint24 fee,
+    int24 tickSpacing,
+    address amm
+  );
 
-    /// @notice Emitted when a new fee amount is enabled for pool creation via the factory
-    /// @param fee The enabled fee, denominated in hundredths of a bip
-    /// @param tickSpacing The minimum number of ticks between initialized ticks for pools created with the given fee
-    event FeeAmountEnabled(uint24 indexed fee, int24 indexed tickSpacing);
+  /// @notice Emitted when a new fee amount is enabled for pool creation via the factory
+  /// @param fee The enabled fee, denominated in hundredths of a bip
+  /// @param tickSpacing The minimum number of ticks between initialized ticks for pools created with the given fee
+  event FeeAmountEnabled(uint24 indexed fee, int24 indexed tickSpacing);
 
-    /// @notice Returns the current owner of the factory
-    /// @dev Can be changed by the current owner via setOwner
-    /// @return The address of the factory owner
-    function owner() external view returns (address);
+  /// @notice Returns the current owner of the factory
+  /// @dev Can be changed by the current owner via setOwner
+  /// @return The address of the factory owner
+  function owner() external view returns (address);
 
-    function treasury() external view returns (address);
+  function treasury() external view returns (address);
 
-    function calculator() external view returns (address);
-    
-    function insuranceFund() external view returns (address);
+  function calculator() external view returns (address);
 
-    function getRateOracleAddress(bytes32 rateOracleId) external view returns (address);
-    
-    /// @notice Returns the tick spacing for a given fee amount, if enabled, or 0 if not enabled
-    /// @dev A fee amount can never be removed, so this value should be hard coded or cached in the calling context
-    /// @param fee The enabled fee, denominated in hundredths of a bip. Returns 0 in case of unenabled fee
-    /// @return The tick spacing
-    function feeAmountTickSpacing(uint24 fee) external view returns (int24);
+  function insuranceFund() external view returns (address);
 
-    function setTreasury(address _treasury) external;
+  function getRateOracleAddress(bytes32 rateOracleId)
+    external
+    view
+    returns (address);
 
-    function setCalculator(address _calculator) external;
+  /// @notice Returns the tick spacing for a given fee amount, if enabled, or 0 if not enabled
+  /// @dev A fee amount can never be removed, so this value should be hard coded or cached in the calling context
+  /// @param fee The enabled fee, denominated in hundredths of a bip. Returns 0 in case of unenabled fee
+  /// @return The tick spacing
+  function feeAmountTickSpacing(uint24 fee) external view returns (int24);
 
-    function setInsuranceFund(address _insuranceFund) external;
+  function setTreasury(address _treasury) external;
 
-    /// @notice Returns the amm address for a given pair of tokens and a fee, or address 0 if it does not exist
-    /// @dev tokenA and tokenB may be passed in either token0/token1 or token1/token0 order
-    /// @param underlyingPool The contract address of the underlying pool
-    /// @param termEndTimestamp Number of days between the inception of the pool and its maturity
-    /// @param termStartTimestamp Timestamp of pool initialisation
-    /// @param fee The fee collected upon every swap in the pool (as a percentage of notional traded), denominated in hundredths of a bip
-    /// @return amm The amm address
-    // function getAMM( // todo: fix
-    //     address underlyingPool,
-    //     uint256 termEndTimestamp,
-    //     uint32 termStartTimestamp,
-    //     uint24 fee
-    // ) external view returns (address amm);
+  function setCalculator(address _calculator) external;
 
-    /// @notice Creates an amm
-    /// @param termEndTimestamp Number of days between the inception of the pool and its maturity
-    /// @param fee The fee collected upon every swap in the pool (as a percentage of notional traded), denominated in hundredths of a bip
-    /// @return amm The address of the newly created amm
-    function createAMM(
-        address underlyingToken,
-        bytes32 rateOracleId,
-        uint256 termEndTimestamp,
-        uint24 fee
-    ) external returns (address amm);
+  function setInsuranceFund(address _insuranceFund) external;
 
-    /// @notice Updates the owner of the factory
-    /// @dev Must be called by the current owner
-    /// @param _owner The new owner of the factory
-    function setOwner(address _owner) external;
+  /// @notice Returns the amm address for a given pair of tokens and a fee, or address 0 if it does not exist
+  /// @dev tokenA and tokenB may be passed in either token0/token1 or token1/token0 order
+  /// @param underlyingPool The contract address of the underlying pool
+  /// @param termEndTimestamp Number of days between the inception of the pool and its maturity
+  /// @param termStartTimestamp Timestamp of pool initialisation
+  /// @param fee The fee collected upon every swap in the pool (as a percentage of notional traded), denominated in hundredths of a bip
+  /// @return amm The amm address
+  // function getAMM( // todo: fix
+  //     address underlyingPool,
+  //     uint256 termEndTimestamp,
+  //     uint32 termStartTimestamp,
+  //     uint24 fee
+  // ) external view returns (address amm);
 
-    /// @notice Enables a fee amount with the given tickSpacing
-    /// @dev Fee amounts may never be removed once enabled
-    /// @param fee The fee amount to enable, denominated in hundredths of a bip (i.e. 1e-6)
-    /// @param tickSpacing The spacing between ticks to be enforced for all pools created with the given fee amount
-    function enableFeeAmount(uint24 fee, int24 tickSpacing) external;
+  /// @notice Creates an amm
+  /// @param termEndTimestamp Number of days between the inception of the pool and its maturity
+  /// @param fee The fee collected upon every swap in the pool (as a percentage of notional traded), denominated in hundredths of a bip
+  /// @return amm The address of the newly created amm
+  function createAMM(
+    address underlyingToken,
+    bytes32 rateOracleId,
+    uint256 termEndTimestamp,
+    uint24 fee
+  ) external returns (address amm);
 
-    function addRateOracle(bytes32 _rateOracleId, address _rateOracleAddress) external;
+  /// @notice Updates the owner of the factory
+  /// @dev Must be called by the current owner
+  /// @param _owner The new owner of the factory
+  function setOwner(address _owner) external;
 
+  /// @notice Enables a fee amount with the given tickSpacing
+  /// @dev Fee amounts may never be removed once enabled
+  /// @param fee The fee amount to enable, denominated in hundredths of a bip (i.e. 1e-6)
+  /// @param tickSpacing The spacing between ticks to be enforced for all pools created with the given fee amount
+  function enableFeeAmount(uint24 fee, int24 tickSpacing) external;
+
+  function addRateOracle(bytes32 _rateOracleId, address _rateOracleAddress)
+    external;
 }

--- a/contracts/interfaces/IAggregator.sol
+++ b/contracts/interfaces/IAggregator.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/interfaces/IERC20Minimal.sol
+++ b/contracts/interfaces/IERC20Minimal.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title Minimal ERC20 interface for Voltz

--- a/contracts/interfaces/IMarginCalculator.sol
+++ b/contracts/interfaces/IMarginCalculator.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "prb-math/contracts/PRBMathUD60x18Typed.sol";
 

--- a/contracts/interfaces/IMarginOracle.sol
+++ b/contracts/interfaces/IMarginOracle.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 interface IMarginOracle {

--- a/contracts/interfaces/IVoltzMarginPricer.sol
+++ b/contracts/interfaces/IVoltzMarginPricer.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 interface IVoltzMarginPricer {

--- a/contracts/interfaces/aave/IAaveV2LendingPool.sol
+++ b/contracts/interfaces/aave/IAaveV2LendingPool.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 pragma abicoder v2;
 

--- a/contracts/interfaces/amm/IAMMActions.sol
+++ b/contracts/interfaces/amm/IAMMActions.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 // import "../../core_libraries/Trader.sol";

--- a/contracts/interfaces/amm/IAMMEvents.sol
+++ b/contracts/interfaces/amm/IAMMEvents.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title Events emitted by an amm

--- a/contracts/interfaces/amm/IAMMImmutables.sol
+++ b/contracts/interfaces/amm/IAMMImmutables.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "../IMarginCalculator.sol";
 import "../rate_oracles/IRateOracle.sol";

--- a/contracts/interfaces/amm/IAMMOwnerActions.sol
+++ b/contracts/interfaces/amm/IAMMOwnerActions.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title Permissioned amm actions

--- a/contracts/interfaces/amm/IAMMState.sol
+++ b/contracts/interfaces/amm/IAMMState.sol
@@ -1,94 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title AMM state that can change
 /// @notice These methods compose the amm's state, and can change with any frequency including multiple times
 /// per transaction
 interface IAMMState {
-    /// @notice The 0th storage slot in the amm stores many values, and is exposed as a single method to save gas
-    /// when accessed externally.
-    /// @return sqrtPriceX96 The current price of the amm as a sqrt(token1/token0) Q64.96 value
-    /// tick The current tick of the amm, i.e. according to the last tick transition that was run.
-    /// This value may not always be equal to SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96) if the price is on a tick
-    /// boundary.
-    function slot0()
-        external
-        view
-        returns (
-            uint160 sqrtPriceX96,
-            int24 tick,
-            uint256 feeProtocol,
-            bool unlocked
-        );
+  /// @notice The 0th storage slot in the amm stores many values, and is exposed as a single method to save gas
+  /// when accessed externally.
+  /// @return sqrtPriceX96 The current price of the amm as a sqrt(token1/token0) Q64.96 value
+  /// tick The current tick of the amm, i.e. according to the last tick transition that was run.
+  /// This value may not always be equal to SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96) if the price is on a tick
+  /// boundary.
+  function slot0()
+    external
+    view
+    returns (
+      uint160 sqrtPriceX96,
+      int24 tick,
+      uint256 feeProtocol,
+      bool unlocked
+    );
 
-    /// @notice The fee growth as a Q128.128 fees of underlying Token collected per unit of liquidity for the entire life of the amm
-    /// @dev This value can overflow the uint256
-    // function feeGrowthGlobalX128() external view returns (uint256);
+  /// @notice The fee growth as a Q128.128 fees of underlying Token collected per unit of liquidity for the entire life of the amm
+  /// @dev This value can overflow the uint256
+  // function feeGrowthGlobalX128() external view returns (uint256);
 
-    // function notionalGrowthGlobal() external view returns (int256);
+  // function notionalGrowthGlobal() external view returns (int256);
 
-    // function notionalGlobal() external view returns (int256);
+  // function notionalGlobal() external view returns (int256);
 
-    // function fixedRateGlobal() external view returns (int256);
+  // function fixedRateGlobal() external view returns (int256);
 
-    function fixedTokenGrowthGlobal() external view returns (int256);
+  function fixedTokenGrowthGlobal() external view returns (int256);
 
-    function variableTokenGrowthGlobal() external view returns (int256);
+  function variableTokenGrowthGlobal() external view returns (int256);
 
-    function feeGrowthGlobal() external view returns (uint256);
+  function feeGrowthGlobal() external view returns (uint256);
 
-    /// @notice The currently in range liquidity available to the amm
-    /// @dev This value has no relationship to the total liquidity across all ticks
-    function liquidity() external view returns (uint128);
+  /// @notice The currently in range liquidity available to the amm
+  /// @dev This value has no relationship to the total liquidity across all ticks
+  function liquidity() external view returns (uint128);
 
-    /// @notice Look up information about a specific tick in the amm
-    /// @param tick The tick to look up
-    /// @return liquidityGross the total amount of position liquidity that uses the amm either as tick lower or
-    /// tick upper,
-    /// liquidityNet how much liquidity changes when the amm price crosses the tick,
-    /// feeGrowthOutsideX128 the fee growth on the other side of the tick from the current tick in underlying Token
-    /// i.e. if liquidityGross is greater than 0. In addition, these values are only relative and are used to
-    /// compute snapshots.
-    function ticks(int24 tick)
-        external
-        view
-        returns (
-            uint128 liquidityGross,
-            int128 liquidityNet,
-            int256 fixedTokenGrowthOutside,
-            int256 variableTokenGrowthOutside,
-            uint256 feeGrowthOutside,
-            bool initialized
-        );
+  /// @notice Look up information about a specific tick in the amm
+  /// @param tick The tick to look up
+  /// @return liquidityGross the total amount of position liquidity that uses the amm either as tick lower or
+  /// tick upper,
+  /// liquidityNet how much liquidity changes when the amm price crosses the tick,
+  /// feeGrowthOutsideX128 the fee growth on the other side of the tick from the current tick in underlying Token
+  /// i.e. if liquidityGross is greater than 0. In addition, these values are only relative and are used to
+  /// compute snapshots.
+  function ticks(int24 tick)
+    external
+    view
+    returns (
+      uint128 liquidityGross,
+      int128 liquidityNet,
+      int256 fixedTokenGrowthOutside,
+      int256 variableTokenGrowthOutside,
+      uint256 feeGrowthOutside,
+      bool initialized
+    );
 
-    /// @notice Returns 256 packed tick initialized boolean values. See TickBitmap for more information
-    function tickBitmap(int16 wordPosition) external view returns (uint256);
+  /// @notice Returns 256 packed tick initialized boolean values. See TickBitmap for more information
+  function tickBitmap(int16 wordPosition) external view returns (uint256);
 
-    /// @notice Returns the information about a position by the position's key
-    /// @param key The position's key is a hash of a preimage composed by the owner, tickLower and tickUpper
-    function positions(bytes32 key)
-        external
-        view
-        returns (
-            uint128 liquidity,
-            int256 margin,
-            int256 fixedTokenGrowthInsideLast,
-            int256 variableTokenGrowthInsideLast,        
-            int256 fixedTokenBalance,
-            int256 variableTokenBalance,
-            uint256 feeGrowthInsideLast
-        );
+  /// @notice Returns the information about a position by the position's key
+  /// @param key The position's key is a hash of a preimage composed by the owner, tickLower and tickUpper
+  function positions(bytes32 key)
+    external
+    view
+    returns (
+      uint128 liquidity,
+      int256 margin,
+      int256 fixedTokenGrowthInsideLast,
+      int256 variableTokenGrowthInsideLast,
+      int256 fixedTokenBalance,
+      int256 variableTokenBalance,
+      uint256 feeGrowthInsideLast
+    );
 
-    /// @notice Returns the information about a trader by the trader key
-    /// @param key The trader's key is a hash of a preimage composed by the owner, notional, fixedRate
-    function traders(bytes32 key)
-        external
-        view
-        returns (
-            int256 margin,
-            int256 fixedTokenBalance,
-            int256 variableTokenBalance,
-            bool settled
-        );
-
-
+  /// @notice Returns the information about a trader by the trader key
+  /// @param key The trader's key is a hash of a preimage composed by the owner, notional, fixedRate
+  function traders(bytes32 key)
+    external
+    view
+    returns (
+      int256 margin,
+      int256 fixedTokenBalance,
+      int256 variableTokenBalance,
+      bool settled
+    );
 }

--- a/contracts/interfaces/callback/IAMMMintCallback.sol
+++ b/contracts/interfaces/callback/IAMMMintCallback.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 pragma solidity ^0.8.0;
 
 /// @title Callback for mint
 /// @notice Any contract that calls mint must implement this interface
 interface IAMMMintCallback {
-    /// @notice Called to `msg.sender` after minting liquidity to a position from AMM mint.
-    /// @dev In the implementation you must pay the pool tokens owed for the minted liquidity (margin)
-    /// The caller of this method must be checked to be a AMM deployed by the canonical AMMFactory.
-    /// @param underlyingTokensOwed The amount of token0 due to the pool for the minted liquidity
-    /// @param data Any data passed through by the caller via the IUniswapV3PoolActions#mint call
-    function ammMintCallback(uint256 underlyingTokensOwed, bytes calldata data)
-        external;
+  /// @notice Called to `msg.sender` after minting liquidity to a position from AMM mint.
+  /// @dev In the implementation you must pay the pool tokens owed for the minted liquidity (margin)
+  /// The caller of this method must be checked to be a AMM deployed by the canonical AMMFactory.
+  /// @param underlyingTokensOwed The amount of token0 due to the pool for the minted liquidity
+  /// @param data Any data passed through by the caller via the IUniswapV3PoolActions#mint call
+  function ammMintCallback(uint256 underlyingTokensOwed, bytes calldata data)
+    external;
 }

--- a/contracts/interfaces/rate_oracles/IAaveRateOracle.sol
+++ b/contracts/interfaces/rate_oracles/IAaveRateOracle.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "../aave/IAaveV2LendingPool.sol";
 import "../rate_oracles/IRateOracle.sol";

--- a/contracts/interfaces/rate_oracles/IRateOracle.sol
+++ b/contracts/interfaces/rate_oracles/IRateOracle.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 interface IRateOracle {

--- a/contracts/pricers/ChainlinkPricer.sol
+++ b/contracts/pricers/ChainlinkPricer.sol
@@ -1,6 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
-import {IVoltzMarginPricer} from "../interfaces/IVoltzMarginPricer.sol";
+import { IVoltzMarginPricer } from "../interfaces/IVoltzMarginPricer.sol";
 import "../interfaces/IMarginOracle.sol";
 import "../interfaces/IAggregator.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
@@ -11,129 +13,126 @@ import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 // contract ChainLinkPricer is IVoltzMarginPricer {
 contract ChainLinkPricer {
-    using SafeMath for uint256; // todo: fine to use SafeMath in here?
+  using SafeMath for uint256; // todo: fine to use SafeMath in here?
 
-    /// @dev base decimals
-    uint256 internal constant BASE = 18;
+  /// @dev base decimals
+  uint256 internal constant BASE = 18;
 
-    /// @notice chainlink response decimals
-    uint256 public aggregatorDecimals;
+  /// @notice chainlink response decimals
+  uint256 public aggregatorDecimals;
 
-    /// @notice the opyn oracle address
-    IMarginOracle public oracle;
+  /// @notice the opyn oracle address
+  IMarginOracle public oracle;
 
-    /// @notice the aggregator for the underlying pool
-    IAggregator public aggregator;
-    address public underlyingPool;
+  /// @notice the aggregator for the underlying pool
+  IAggregator public aggregator;
+  address public underlyingPool;
 
-    /// @notice bot address that is allowed to call []
-    address public bot;
+  /// @notice bot address that is allowed to call []
+  address public bot;
 
-    /**
-     * @param _bot priveleged address that can call setConfidenceBoundInOracle
-     * @param _underlyingPool underlying pool that this pricer will get a confidence bound for
-     * @param _aggregator Chainlink aggregator contract for the underlying pool
-     * @param _oracle Voltz Margin Oracle address
-     */
-    constructor(
-        address _bot,
-        address _underlyingPool,
-        address _aggregator,
-        address _oracle
-    ) public {
-        require(
-            _bot != address(0),
-            "ChainLinkPricer: Cannot set 0 address as bot"
-        );
-        require(
-            _oracle != address(0),
-            "ChainLinkPricer: Cannot set 0 address as oracle"
-        );
-        require(
-            _aggregator != address(0),
-            "ChainLinkPricer: Cannot set 0 address as aggregator"
-        );
+  /**
+   * @param _bot priveleged address that can call setConfidenceBoundInOracle
+   * @param _underlyingPool underlying pool that this pricer will get a confidence bound for
+   * @param _aggregator Chainlink aggregator contract for the underlying pool
+   * @param _oracle Voltz Margin Oracle address
+   */
+  constructor(
+    address _bot,
+    address _underlyingPool,
+    address _aggregator,
+    address _oracle
+  ) {
+    require(_bot != address(0), "ChainLinkPricer: Cannot set 0 address as bot");
+    require(
+      _oracle != address(0),
+      "ChainLinkPricer: Cannot set 0 address as oracle"
+    );
+    require(
+      _aggregator != address(0),
+      "ChainLinkPricer: Cannot set 0 address as aggregator"
+    );
 
-        bot = _bot;
-        oracle = IMarginOracle(_oracle);
-        aggregator = IAggregator(_aggregator);
-        underlyingPool = _underlyingPool;
+    bot = _bot;
+    oracle = IMarginOracle(_oracle);
+    aggregator = IAggregator(_aggregator);
+    underlyingPool = _underlyingPool;
 
-        aggregatorDecimals = uint256(aggregator.decimals());
+    aggregatorDecimals = uint256(aggregator.decimals());
+  }
+
+  /**
+   * @notice modifier to check if sender address is equal to bot address
+   */
+  modifier onlyBot() {
+    require(msg.sender == bot, "ChainLinkPricer: unauthorized sender");
+
+    _;
+  }
+
+  /**
+   * @notice set the confidence bound in the oracle, can only be called by Bot address
+   */
+  function setConfidenceBoundInOracle(bool isLower, uint80 _roundId)
+    external
+    onlyBot
+  {
+    (, int256 confidenceBound, , uint256 roundTimestamp, ) = aggregator
+      .getRoundData(_roundId);
+
+    // require(_expiryTimestamp <= roundTimestamp, "ChainLinkPricer: invalid roundId"); todo: is this relevant to Voltz?
+
+    oracle.setConfidenceBound(
+      underlyingPool,
+      uint256(confidenceBound),
+      isLower
+    );
+  }
+
+  /**
+   * @notice get the live confidence bound for the asset
+   * @dev overides the getConfidenceBound function in IVoltzMarginPricer
+   * @return confidence bound of the underlyingPool
+   */
+  // todo: add to the interface
+  function getConfidenceBound() external view returns (uint256) {
+    (, int256 answer, , , ) = aggregator.latestRoundData(); // todo: can you pass isLower to the aggregator,
+
+    require(answer > 0, "ChainLinkPricer: confidenceBound is lower than 0");
+
+    // chainlink's answer is 1e8
+    return _scaleToBase(uint256(answer));
+  }
+
+  // todo: not sure this is necessary
+  // /**
+  //  * @notice get historical chainlink price
+  //  * @param _roundId chainlink round id
+  //  * @return round price and timestamp
+  //  */
+  // function getHistoricalPrice(uint80 _roundId) external view override returns (uint256, uint256) {
+  //     (, int256 price, , uint256 roundTimestamp, ) = aggregator.getRoundData(_roundId);
+  //     return (_scaleToBase(uint256(price)), roundTimestamp);
+  // }
+
+  /**
+   * @notice scale aggregator response to base decimals (1e18)
+   * @param _confidenceBound aggregator confidence bound
+   * @return price scaled to 1e18
+   */
+  function _scaleToBase(uint256 _confidenceBound)
+    internal
+    view
+    returns (uint256)
+  {
+    if (aggregatorDecimals > BASE) {
+      uint256 exp = aggregatorDecimals.sub(BASE);
+      _confidenceBound = _confidenceBound.div(10**exp);
+    } else if (aggregatorDecimals < BASE) {
+      uint256 exp = BASE.sub(aggregatorDecimals);
+      _confidenceBound = _confidenceBound.mul(10**exp);
     }
 
-    /**
-     * @notice modifier to check if sender address is equal to bot address
-     */
-    modifier onlyBot() {
-        require(msg.sender == bot, "ChainLinkPricer: unauthorized sender");
-
-        _;
-    }
-
-    /**
-     * @notice set the confidence bound in the oracle, can only be called by Bot address
-     */
-    function setConfidenceBoundInOracle(bool isLower, uint80 _roundId)
-        external
-        onlyBot
-    {
-        (, int256 confidenceBound, , uint256 roundTimestamp, ) = aggregator
-            .getRoundData(_roundId);
-
-        // require(_expiryTimestamp <= roundTimestamp, "ChainLinkPricer: invalid roundId"); todo: is this relevant to Voltz?
-
-        oracle.setConfidenceBound(
-            underlyingPool,
-            uint256(confidenceBound),
-            isLower
-        );
-    }
-
-    /**
-     * @notice get the live confidence bound for the asset
-     * @dev overides the getConfidenceBound function in IVoltzMarginPricer
-     * @return confidence bound of the underlyingPool
-     */
-    // todo: add to the interface
-    function getConfidenceBound() external view returns (uint256) {
-        (, int256 answer, , , ) = aggregator.latestRoundData(); // todo: can you pass isLower to the aggregator,
-
-        require(answer > 0, "ChainLinkPricer: confidenceBound is lower than 0");
-
-        // chainlink's answer is 1e8
-        return _scaleToBase(uint256(answer));
-    }
-
-    // todo: not sure this is necessary
-    // /**
-    //  * @notice get historical chainlink price
-    //  * @param _roundId chainlink round id
-    //  * @return round price and timestamp
-    //  */
-    // function getHistoricalPrice(uint80 _roundId) external view override returns (uint256, uint256) {
-    //     (, int256 price, , uint256 roundTimestamp, ) = aggregator.getRoundData(_roundId);
-    //     return (_scaleToBase(uint256(price)), roundTimestamp);
-    // }
-
-    /**
-     * @notice scale aggregator response to base decimals (1e18)
-     * @param _confidenceBound aggregator confidence bound
-     * @return price scaled to 1e18
-     */
-    function _scaleToBase(uint256 _confidenceBound)
-        internal
-        view
-        returns (uint256)
-    {
-        if (aggregatorDecimals > BASE) {
-            uint256 exp = aggregatorDecimals.sub(BASE);
-            _confidenceBound = _confidenceBound.div(10**exp);
-        } else if (aggregatorDecimals < BASE) {
-            uint256 exp = BASE.sub(aggregatorDecimals);
-            _confidenceBound = _confidenceBound.mul(10**exp);
-        }
-
-        return _confidenceBound;
-    }
+    return _confidenceBound;
+  }
 }

--- a/contracts/rate_oracles/AaveRateOracle.sol
+++ b/contracts/rate_oracles/AaveRateOracle.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "../interfaces/rate_oracles/IAaveRateOracle.sol";

--- a/contracts/rate_oracles/BaseRateOracle.sol
+++ b/contracts/rate_oracles/BaseRateOracle.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "../interfaces/rate_oracles/IRateOracle.sol";

--- a/contracts/test/AaveRateOracleTest.sol
+++ b/contracts/test/AaveRateOracleTest.sol
@@ -1,7 +1,9 @@
-// pragma solidity ^0.8.0;
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
 // import "../rate_oracles/AaveRateOracle.sol";
 // import "../core_libraries/FixedAndVariableMath.sol";
-
 
 // contract AaveRateOracleTest is AaveRateOracle {
 
@@ -13,7 +15,7 @@
 //     function variableFactorTest(bool atMaturity, address underlyingToken, uint256 termStartTimestamp, uint256 termEndTimestamp) public returns(uint256 result) {
 //         mostRecentVariableFactor = variableFactor(atMaturity, underlyingToken, termStartTimestamp, termEndTimestamp);
 //     }
-    
+
 //     // function getReserveNormalizedIncome(address underlying) public view override returns(uint256){
 //     //     return lendingPool.getReserveNormalizedIncome(underlying);
 //     // }
@@ -29,10 +31,7 @@
 //         } else {
 //             endRate = rates[underlying][FixedAndVariableMath.blockTimestampScaled()];
 //         }
-        
+
 //     }
-
-
-
 
 // }

--- a/contracts/test/FixedAndVariableMathTest.sol
+++ b/contracts/test/FixedAndVariableMathTest.sol
@@ -1,10 +1,13 @@
-// pragma solidity ^0.8.0;
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
 // import "../core_libraries/FixedAndVariableMath.sol";
 
 // contract FixedAndVariableMathTest {
-    
+
 //     function accrualFact(uint256 timeInSeconds) external pure returns(uint256 timeInYears) {
 //         return FixedAndVariableMath.accrualFact(timeInSeconds);
 //     }
-    
+
 // }

--- a/contracts/test/MarginCalculatorTest.sol
+++ b/contracts/test/MarginCalculatorTest.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "../MarginCalculator.sol";
 import "../interfaces/IMarginCalculator.sol";

--- a/contracts/test/PositionTest.sol
+++ b/contracts/test/PositionTest.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "../core_libraries/Position.sol";
 

--- a/contracts/test/SqrtPriceMathTest.sol
+++ b/contracts/test/SqrtPriceMathTest.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "../utils/SqrtPriceMath.sol";
 

--- a/contracts/test/TestAMM.sol
+++ b/contracts/test/TestAMM.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "../utils/SafeCast.sol";
@@ -28,4 +30,3 @@ contract TestAMM is AMM {
     }
 
 }
-

--- a/contracts/test/TestAMMCallee.sol
+++ b/contracts/test/TestAMMCallee.sol
@@ -1,4 +1,6 @@
-// pragma solidity ^0.8.0;
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
 
 // import "../utils/SafeCast.sol";
 // import "../utils/TickMath.sol";
@@ -26,7 +28,7 @@
 //     function updatePositionTest(ModifyPositionParams memory params) external returns(Position.Info memory position) {
 //         return _updatePosition(params);
 //     }
-    
+
 //     function swapExact0For1(
 //         address amm,
 //         uint256 amount0In,

--- a/contracts/utils/BitMath.sol
+++ b/contracts/utils/BitMath.sol
@@ -1,94 +1,95 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 pragma solidity ^0.8.0;
 
 /// @title BitMath
 /// @dev This library provides functionality for computing bit properties of an unsigned integer
 library BitMath {
-    /// @notice Returns the index of the most significant bit of the number,
-    ///     where the least significant bit is at index 0 and the most significant bit is at index 255
-    /// @dev The function satisfies the property:
-    ///     x >= 2**mostSignificantBit(x) and x < 2**(mostSignificantBit(x)+1)
-    /// @param x the value for which to compute the most significant bit, must be greater than 0
-    /// @return r the index of the most significant bit
-    function mostSignificantBit(uint256 x) internal pure returns (uint8 r) {
-        require(x > 0);
+  /// @notice Returns the index of the most significant bit of the number,
+  ///     where the least significant bit is at index 0 and the most significant bit is at index 255
+  /// @dev The function satisfies the property:
+  ///     x >= 2**mostSignificantBit(x) and x < 2**(mostSignificantBit(x)+1)
+  /// @param x the value for which to compute the most significant bit, must be greater than 0
+  /// @return r the index of the most significant bit
+  function mostSignificantBit(uint256 x) internal pure returns (uint8 r) {
+    require(x > 0);
 
-        if (x >= 0x100000000000000000000000000000000) {
-            x >>= 128;
-            r += 128;
-        }
-        if (x >= 0x10000000000000000) {
-            x >>= 64;
-            r += 64;
-        }
-        if (x >= 0x100000000) {
-            x >>= 32;
-            r += 32;
-        }
-        if (x >= 0x10000) {
-            x >>= 16;
-            r += 16;
-        }
-        if (x >= 0x100) {
-            x >>= 8;
-            r += 8;
-        }
-        if (x >= 0x10) {
-            x >>= 4;
-            r += 4;
-        }
-        if (x >= 0x4) {
-            x >>= 2;
-            r += 2;
-        }
-        if (x >= 0x2) r += 1;
+    if (x >= 0x100000000000000000000000000000000) {
+      x >>= 128;
+      r += 128;
     }
-
-    /// @notice Returns the index of the least significant bit of the number,
-    ///     where the least significant bit is at index 0 and the most significant bit is at index 255
-    /// @dev The function satisfies the property:
-    ///     (x & 2**leastSignificantBit(x)) != 0 and (x & (2**(leastSignificantBit(x)) - 1)) == 0)
-    /// @param x the value for which to compute the least significant bit, must be greater than 0
-    /// @return r the index of the least significant bit
-    function leastSignificantBit(uint256 x) internal pure returns (uint8 r) {
-        require(x > 0);
-
-        r = 255;
-        if (x & type(uint128).max > 0) {
-            r -= 128;
-        } else {
-            x >>= 128;
-        }
-        if (x & type(uint64).max > 0) {
-            r -= 64;
-        } else {
-            x >>= 64;
-        }
-        if (x & type(uint32).max > 0) {
-            r -= 32;
-        } else {
-            x >>= 32;
-        }
-        if (x & type(uint16).max > 0) {
-            r -= 16;
-        } else {
-            x >>= 16;
-        }
-        if (x & type(uint8).max > 0) {
-            r -= 8;
-        } else {
-            x >>= 8;
-        }
-        if (x & 0xf > 0) {
-            r -= 4;
-        } else {
-            x >>= 4;
-        }
-        if (x & 0x3 > 0) {
-            r -= 2;
-        } else {
-            x >>= 2;
-        }
-        if (x & 0x1 > 0) r -= 1;
+    if (x >= 0x10000000000000000) {
+      x >>= 64;
+      r += 64;
     }
+    if (x >= 0x100000000) {
+      x >>= 32;
+      r += 32;
+    }
+    if (x >= 0x10000) {
+      x >>= 16;
+      r += 16;
+    }
+    if (x >= 0x100) {
+      x >>= 8;
+      r += 8;
+    }
+    if (x >= 0x10) {
+      x >>= 4;
+      r += 4;
+    }
+    if (x >= 0x4) {
+      x >>= 2;
+      r += 2;
+    }
+    if (x >= 0x2) r += 1;
+  }
+
+  /// @notice Returns the index of the least significant bit of the number,
+  ///     where the least significant bit is at index 0 and the most significant bit is at index 255
+  /// @dev The function satisfies the property:
+  ///     (x & 2**leastSignificantBit(x)) != 0 and (x & (2**(leastSignificantBit(x)) - 1)) == 0)
+  /// @param x the value for which to compute the least significant bit, must be greater than 0
+  /// @return r the index of the least significant bit
+  function leastSignificantBit(uint256 x) internal pure returns (uint8 r) {
+    require(x > 0);
+
+    r = 255;
+    if (x & type(uint128).max > 0) {
+      r -= 128;
+    } else {
+      x >>= 128;
+    }
+    if (x & type(uint64).max > 0) {
+      r -= 64;
+    } else {
+      x >>= 64;
+    }
+    if (x & type(uint32).max > 0) {
+      r -= 32;
+    } else {
+      x >>= 32;
+    }
+    if (x & type(uint16).max > 0) {
+      r -= 16;
+    } else {
+      x >>= 16;
+    }
+    if (x & type(uint8).max > 0) {
+      r -= 8;
+    } else {
+      x >>= 8;
+    }
+    if (x & 0xf > 0) {
+      r -= 4;
+    } else {
+      x >>= 4;
+    }
+    if (x & 0x3 > 0) {
+      r -= 2;
+    } else {
+      x >>= 2;
+    }
+    if (x & 0x1 > 0) r -= 1;
+  }
 }

--- a/contracts/utils/Errors.sol
+++ b/contracts/utils/Errors.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pragma solidity ^0.8.0;
 
 /**
@@ -19,103 +21,103 @@ pragma solidity ^0.8.0;
  *  - P = Pausable
  */
 library Errors {
-    //common errors
-    string public constant CALLER_NOT_POOL_ADMIN = "33"; // "The caller must be the pool admin"
-    string public constant BORROW_ALLOWANCE_NOT_ENOUGH = "59"; // User borrows on behalf, but allowance are too small
+  //common errors
+  string public constant CALLER_NOT_POOL_ADMIN = "33"; // "The caller must be the pool admin"
+  string public constant BORROW_ALLOWANCE_NOT_ENOUGH = "59"; // User borrows on behalf, but allowance are too small
 
-    //contract specific errors
-    string public constant VL_INVALID_AMOUNT = "1"; // "Amount must be greater than 0"
-    string public constant VL_NO_ACTIVE_RESERVE = "2"; // "Action requires an active reserve"
-    string public constant VL_RESERVE_FROZEN = "3"; // "Action cannot be performed because the reserve is frozen"
-    string public constant VL_CURRENT_AVAILABLE_LIQUIDITY_NOT_ENOUGH = "4"; // "The current liquidity is not enough"
-    string public constant VL_NOT_ENOUGH_AVAILABLE_USER_BALANCE = "5"; // "User cannot withdraw more than the available balance"
-    string public constant VL_TRANSFER_NOT_ALLOWED = "6"; // "Transfer cannot be allowed."
-    string public constant VL_BORROWING_NOT_ENABLED = "7"; // "Borrowing is not enabled"
-    string public constant VL_INVALID_INTEREST_RATE_MODE_SELECTED = "8"; // "Invalid interest rate mode selected"
-    string public constant VL_COLLATERAL_BALANCE_IS_0 = "9"; // "The collateral balance is 0"
-    string public constant VL_HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD =
-        "10"; // "Health factor is lesser than the liquidation threshold"
-    string public constant VL_COLLATERAL_CANNOT_COVER_NEW_BORROW = "11"; // "There is not enough collateral to cover a new borrow"
-    string public constant VL_STABLE_BORROWING_NOT_ENABLED = "12"; // stable borrowing not enabled
-    string public constant VL_COLLATERAL_SAME_AS_BORROWING_CURRENCY = "13"; // collateral is (mostly) the same currency that is being borrowed
-    string public constant VL_AMOUNT_BIGGER_THAN_MAX_LOAN_SIZE_STABLE = "14"; // "The requested amount is greater than the max loan size in stable rate mode
-    string public constant VL_NO_DEBT_OF_SELECTED_TYPE = "15"; // "for repayment of stable debt, the user needs to have stable debt, otherwise, he needs to have variable debt"
-    string public constant VL_NO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF = "16"; // "To repay on behalf of an user an explicit amount to repay is needed"
-    string public constant VL_NO_STABLE_RATE_LOAN_IN_RESERVE = "17"; // "User does not have a stable rate loan in progress on this reserve"
-    string public constant VL_NO_VARIABLE_RATE_LOAN_IN_RESERVE = "18"; // "User does not have a variable rate loan in progress on this reserve"
-    string public constant VL_UNDERLYING_BALANCE_NOT_GREATER_THAN_0 = "19"; // "The underlying balance needs to be greater than 0"
-    string public constant VL_DEPOSIT_ALREADY_IN_USE = "20"; // "User deposit is already being used as collateral"
-    string public constant LP_NOT_ENOUGH_STABLE_BORROW_BALANCE = "21"; // "User does not have any stable rate loan for this reserve"
-    string public constant LP_INTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET = "22"; // "Interest rate rebalance conditions were not met"
-    string public constant LP_LIQUIDATION_CALL_FAILED = "23"; // "Liquidation call failed"
-    string public constant LP_NOT_ENOUGH_LIQUIDITY_TO_BORROW = "24"; // "There is not enough liquidity available to borrow"
-    string public constant LP_REQUESTED_AMOUNT_TOO_SMALL = "25"; // "The requested amount is too small for a FlashLoan."
-    string public constant LP_INCONSISTENT_PROTOCOL_ACTUAL_BALANCE = "26"; // "The actual balance of the protocol is inconsistent"
-    string public constant LP_CALLER_NOT_LENDING_POOL_CONFIGURATOR = "27"; // "The caller of the function is not the lending pool configurator"
-    string public constant LP_INCONSISTENT_FLASHLOAN_PARAMS = "28";
-    string public constant CT_CALLER_MUST_BE_LENDING_POOL = "29"; // "The caller of this function must be a lending pool"
-    string public constant CT_CANNOT_GIVE_ALLOWANCE_TO_HIMSELF = "30"; // "User cannot give allowance to himself"
-    string public constant CT_TRANSFER_AMOUNT_NOT_GT_0 = "31"; // "Transferred amount needs to be greater than zero"
-    string public constant RL_RESERVE_ALREADY_INITIALIZED = "32"; // "Reserve has already been initialized"
-    string public constant LPC_RESERVE_LIQUIDITY_NOT_0 = "34"; // "The liquidity of the reserve needs to be 0"
-    string public constant LPC_INVALID_ATOKEN_POOL_ADDRESS = "35"; // "The liquidity of the reserve needs to be 0"
-    string public constant LPC_INVALID_STABLE_DEBT_TOKEN_POOL_ADDRESS = "36"; // "The liquidity of the reserve needs to be 0"
-    string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_POOL_ADDRESS = "37"; // "The liquidity of the reserve needs to be 0"
-    string public constant LPC_INVALID_STABLE_DEBT_TOKEN_UNDERLYING_ADDRESS =
-        "38"; // "The liquidity of the reserve needs to be 0"
-    string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_UNDERLYING_ADDRESS =
-        "39"; // "The liquidity of the reserve needs to be 0"
-    string public constant LPC_INVALID_ADDRESSES_PROVIDER_ID = "40"; // "The liquidity of the reserve needs to be 0"
-    string public constant LPC_INVALID_CONFIGURATION = "75"; // "Invalid risk parameters for the reserve"
-    string public constant LPC_CALLER_NOT_EMERGENCY_ADMIN = "76"; // "The caller must be the emergency admin"
-    string public constant LPAPR_PROVIDER_NOT_REGISTERED = "41"; // "Provider is not registered"
-    string public constant LPCM_HEALTH_FACTOR_NOT_BELOW_THRESHOLD = "42"; // "Health factor is not below the threshold"
-    string public constant LPCM_COLLATERAL_CANNOT_BE_LIQUIDATED = "43"; // "The collateral chosen cannot be liquidated"
-    string public constant LPCM_SPECIFIED_CURRENCY_NOT_BORROWED_BY_USER = "44"; // "User did not borrow the specified currency"
-    string public constant LPCM_NOT_ENOUGH_LIQUIDITY_TO_LIQUIDATE = "45"; // "There isn"t enough liquidity available to liquidate"
-    string public constant LPCM_NO_ERRORS = "46"; // "No errors"
-    string public constant LP_INVALID_FLASHLOAN_MODE = "47"; //Invalid flashloan mode selected
-    string public constant MATH_MULTIPLICATION_OVERFLOW = "48";
-    string public constant MATH_ADDITION_OVERFLOW = "49";
-    string public constant MATH_DIVISION_BY_ZERO = "50";
-    string public constant RL_LIQUIDITY_INDEX_OVERFLOW = "51"; //  Liquidity index overflows uint128
-    string public constant RL_VARIABLE_BORROW_INDEX_OVERFLOW = "52"; //  Variable borrow index overflows uint128
-    string public constant RL_LIQUIDITY_RATE_OVERFLOW = "53"; //  Liquidity rate overflows uint128
-    string public constant RL_VARIABLE_BORROW_RATE_OVERFLOW = "54"; //  Variable borrow rate overflows uint128
-    string public constant RL_STABLE_BORROW_RATE_OVERFLOW = "55"; //  Stable borrow rate overflows uint128
-    string public constant CT_INVALID_MINT_AMOUNT = "56"; //invalid amount to mint
-    string public constant LP_FAILED_REPAY_WITH_COLLATERAL = "57";
-    string public constant CT_INVALID_BURN_AMOUNT = "58"; //invalid amount to burn
-    string public constant LP_FAILED_COLLATERAL_SWAP = "60";
-    string public constant LP_INVALID_EQUAL_ASSETS_TO_SWAP = "61";
-    string public constant LP_REENTRANCY_NOT_ALLOWED = "62";
-    string public constant LP_CALLER_MUST_BE_AN_ATOKEN = "63";
-    string public constant LP_IS_PAUSED = "64"; // "Pool is paused"
-    string public constant LP_NO_MORE_RESERVES_ALLOWED = "65";
-    string public constant LP_INVALID_FLASH_LOAN_EXECUTOR_RETURN = "66";
-    string public constant RC_INVALID_LTV = "67";
-    string public constant RC_INVALID_LIQ_THRESHOLD = "68";
-    string public constant RC_INVALID_LIQ_BONUS = "69";
-    string public constant RC_INVALID_DECIMALS = "70";
-    string public constant RC_INVALID_RESERVE_FACTOR = "71";
-    string public constant LPAPR_INVALID_ADDRESSES_PROVIDER_ID = "72";
-    string public constant VL_INCONSISTENT_FLASHLOAN_PARAMS = "73";
-    string public constant LP_INCONSISTENT_PARAMS_LENGTH = "74";
-    string public constant UL_INVALID_INDEX = "77";
-    string public constant LP_NOT_CONTRACT = "78";
-    string public constant SDT_STABLE_DEBT_OVERFLOW = "79";
-    string public constant SDT_BURN_EXCEEDS_BALANCE = "80";
+  //contract specific errors
+  string public constant VL_INVALID_AMOUNT = "1"; // "Amount must be greater than 0"
+  string public constant VL_NO_ACTIVE_RESERVE = "2"; // "Action requires an active reserve"
+  string public constant VL_RESERVE_FROZEN = "3"; // "Action cannot be performed because the reserve is frozen"
+  string public constant VL_CURRENT_AVAILABLE_LIQUIDITY_NOT_ENOUGH = "4"; // "The current liquidity is not enough"
+  string public constant VL_NOT_ENOUGH_AVAILABLE_USER_BALANCE = "5"; // "User cannot withdraw more than the available balance"
+  string public constant VL_TRANSFER_NOT_ALLOWED = "6"; // "Transfer cannot be allowed."
+  string public constant VL_BORROWING_NOT_ENABLED = "7"; // "Borrowing is not enabled"
+  string public constant VL_INVALID_INTEREST_RATE_MODE_SELECTED = "8"; // "Invalid interest rate mode selected"
+  string public constant VL_COLLATERAL_BALANCE_IS_0 = "9"; // "The collateral balance is 0"
+  string public constant VL_HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD =
+    "10"; // "Health factor is lesser than the liquidation threshold"
+  string public constant VL_COLLATERAL_CANNOT_COVER_NEW_BORROW = "11"; // "There is not enough collateral to cover a new borrow"
+  string public constant VL_STABLE_BORROWING_NOT_ENABLED = "12"; // stable borrowing not enabled
+  string public constant VL_COLLATERAL_SAME_AS_BORROWING_CURRENCY = "13"; // collateral is (mostly) the same currency that is being borrowed
+  string public constant VL_AMOUNT_BIGGER_THAN_MAX_LOAN_SIZE_STABLE = "14"; // "The requested amount is greater than the max loan size in stable rate mode
+  string public constant VL_NO_DEBT_OF_SELECTED_TYPE = "15"; // "for repayment of stable debt, the user needs to have stable debt, otherwise, he needs to have variable debt"
+  string public constant VL_NO_EXPLICIT_AMOUNT_TO_REPAY_ON_BEHALF = "16"; // "To repay on behalf of an user an explicit amount to repay is needed"
+  string public constant VL_NO_STABLE_RATE_LOAN_IN_RESERVE = "17"; // "User does not have a stable rate loan in progress on this reserve"
+  string public constant VL_NO_VARIABLE_RATE_LOAN_IN_RESERVE = "18"; // "User does not have a variable rate loan in progress on this reserve"
+  string public constant VL_UNDERLYING_BALANCE_NOT_GREATER_THAN_0 = "19"; // "The underlying balance needs to be greater than 0"
+  string public constant VL_DEPOSIT_ALREADY_IN_USE = "20"; // "User deposit is already being used as collateral"
+  string public constant LP_NOT_ENOUGH_STABLE_BORROW_BALANCE = "21"; // "User does not have any stable rate loan for this reserve"
+  string public constant LP_INTEREST_RATE_REBALANCE_CONDITIONS_NOT_MET = "22"; // "Interest rate rebalance conditions were not met"
+  string public constant LP_LIQUIDATION_CALL_FAILED = "23"; // "Liquidation call failed"
+  string public constant LP_NOT_ENOUGH_LIQUIDITY_TO_BORROW = "24"; // "There is not enough liquidity available to borrow"
+  string public constant LP_REQUESTED_AMOUNT_TOO_SMALL = "25"; // "The requested amount is too small for a FlashLoan."
+  string public constant LP_INCONSISTENT_PROTOCOL_ACTUAL_BALANCE = "26"; // "The actual balance of the protocol is inconsistent"
+  string public constant LP_CALLER_NOT_LENDING_POOL_CONFIGURATOR = "27"; // "The caller of the function is not the lending pool configurator"
+  string public constant LP_INCONSISTENT_FLASHLOAN_PARAMS = "28";
+  string public constant CT_CALLER_MUST_BE_LENDING_POOL = "29"; // "The caller of this function must be a lending pool"
+  string public constant CT_CANNOT_GIVE_ALLOWANCE_TO_HIMSELF = "30"; // "User cannot give allowance to himself"
+  string public constant CT_TRANSFER_AMOUNT_NOT_GT_0 = "31"; // "Transferred amount needs to be greater than zero"
+  string public constant RL_RESERVE_ALREADY_INITIALIZED = "32"; // "Reserve has already been initialized"
+  string public constant LPC_RESERVE_LIQUIDITY_NOT_0 = "34"; // "The liquidity of the reserve needs to be 0"
+  string public constant LPC_INVALID_ATOKEN_POOL_ADDRESS = "35"; // "The liquidity of the reserve needs to be 0"
+  string public constant LPC_INVALID_STABLE_DEBT_TOKEN_POOL_ADDRESS = "36"; // "The liquidity of the reserve needs to be 0"
+  string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_POOL_ADDRESS = "37"; // "The liquidity of the reserve needs to be 0"
+  string public constant LPC_INVALID_STABLE_DEBT_TOKEN_UNDERLYING_ADDRESS =
+    "38"; // "The liquidity of the reserve needs to be 0"
+  string public constant LPC_INVALID_VARIABLE_DEBT_TOKEN_UNDERLYING_ADDRESS =
+    "39"; // "The liquidity of the reserve needs to be 0"
+  string public constant LPC_INVALID_ADDRESSES_PROVIDER_ID = "40"; // "The liquidity of the reserve needs to be 0"
+  string public constant LPC_INVALID_CONFIGURATION = "75"; // "Invalid risk parameters for the reserve"
+  string public constant LPC_CALLER_NOT_EMERGENCY_ADMIN = "76"; // "The caller must be the emergency admin"
+  string public constant LPAPR_PROVIDER_NOT_REGISTERED = "41"; // "Provider is not registered"
+  string public constant LPCM_HEALTH_FACTOR_NOT_BELOW_THRESHOLD = "42"; // "Health factor is not below the threshold"
+  string public constant LPCM_COLLATERAL_CANNOT_BE_LIQUIDATED = "43"; // "The collateral chosen cannot be liquidated"
+  string public constant LPCM_SPECIFIED_CURRENCY_NOT_BORROWED_BY_USER = "44"; // "User did not borrow the specified currency"
+  string public constant LPCM_NOT_ENOUGH_LIQUIDITY_TO_LIQUIDATE = "45"; // "There isn"t enough liquidity available to liquidate"
+  string public constant LPCM_NO_ERRORS = "46"; // "No errors"
+  string public constant LP_INVALID_FLASHLOAN_MODE = "47"; //Invalid flashloan mode selected
+  string public constant MATH_MULTIPLICATION_OVERFLOW = "48";
+  string public constant MATH_ADDITION_OVERFLOW = "49";
+  string public constant MATH_DIVISION_BY_ZERO = "50";
+  string public constant RL_LIQUIDITY_INDEX_OVERFLOW = "51"; //  Liquidity index overflows uint128
+  string public constant RL_VARIABLE_BORROW_INDEX_OVERFLOW = "52"; //  Variable borrow index overflows uint128
+  string public constant RL_LIQUIDITY_RATE_OVERFLOW = "53"; //  Liquidity rate overflows uint128
+  string public constant RL_VARIABLE_BORROW_RATE_OVERFLOW = "54"; //  Variable borrow rate overflows uint128
+  string public constant RL_STABLE_BORROW_RATE_OVERFLOW = "55"; //  Stable borrow rate overflows uint128
+  string public constant CT_INVALID_MINT_AMOUNT = "56"; //invalid amount to mint
+  string public constant LP_FAILED_REPAY_WITH_COLLATERAL = "57";
+  string public constant CT_INVALID_BURN_AMOUNT = "58"; //invalid amount to burn
+  string public constant LP_FAILED_COLLATERAL_SWAP = "60";
+  string public constant LP_INVALID_EQUAL_ASSETS_TO_SWAP = "61";
+  string public constant LP_REENTRANCY_NOT_ALLOWED = "62";
+  string public constant LP_CALLER_MUST_BE_AN_ATOKEN = "63";
+  string public constant LP_IS_PAUSED = "64"; // "Pool is paused"
+  string public constant LP_NO_MORE_RESERVES_ALLOWED = "65";
+  string public constant LP_INVALID_FLASH_LOAN_EXECUTOR_RETURN = "66";
+  string public constant RC_INVALID_LTV = "67";
+  string public constant RC_INVALID_LIQ_THRESHOLD = "68";
+  string public constant RC_INVALID_LIQ_BONUS = "69";
+  string public constant RC_INVALID_DECIMALS = "70";
+  string public constant RC_INVALID_RESERVE_FACTOR = "71";
+  string public constant LPAPR_INVALID_ADDRESSES_PROVIDER_ID = "72";
+  string public constant VL_INCONSISTENT_FLASHLOAN_PARAMS = "73";
+  string public constant LP_INCONSISTENT_PARAMS_LENGTH = "74";
+  string public constant UL_INVALID_INDEX = "77";
+  string public constant LP_NOT_CONTRACT = "78";
+  string public constant SDT_STABLE_DEBT_OVERFLOW = "79";
+  string public constant SDT_BURN_EXCEEDS_BALANCE = "80";
 
-    enum CollateralManagerErrors {
-        NO_ERROR,
-        NO_COLLATERAL_AVAILABLE,
-        COLLATERAL_CANNOT_BE_LIQUIDATED,
-        CURRRENCY_NOT_BORROWED,
-        HEALTH_FACTOR_ABOVE_THRESHOLD,
-        NOT_ENOUGH_LIQUIDITY,
-        NO_ACTIVE_RESERVE,
-        HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD,
-        INVALID_EQUAL_ASSETS_TO_SWAP,
-        FROZEN_RESERVE
-    }
+  enum CollateralManagerErrors {
+    NO_ERROR,
+    NO_COLLATERAL_AVAILABLE,
+    COLLATERAL_CANNOT_BE_LIQUIDATED,
+    CURRRENCY_NOT_BORROWED,
+    HEALTH_FACTOR_ABOVE_THRESHOLD,
+    NOT_ENOUGH_LIQUIDITY,
+    NO_ACTIVE_RESERVE,
+    HEALTH_FACTOR_LOWER_THAN_LIQUIDATION_THRESHOLD,
+    INVALID_EQUAL_ASSETS_TO_SWAP,
+    FROZEN_RESERVE
+  }
 }

--- a/contracts/utils/FixedPoint128.sol
+++ b/contracts/utils/FixedPoint128.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title FixedPoint128

--- a/contracts/utils/FixedPoint96.sol
+++ b/contracts/utils/FixedPoint96.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title FixedPoint96

--- a/contracts/utils/FullMath.sol
+++ b/contracts/utils/FullMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/contracts/utils/LiquidityMath.sol
+++ b/contracts/utils/LiquidityMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title Math library for liquidity

--- a/contracts/utils/LowGasSafeMath.sol
+++ b/contracts/utils/LowGasSafeMath.sol
@@ -1,78 +1,79 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 pragma solidity ^0.8.0;
 
 /// @title Optimized overflow and underflow safe math operations
 /// @notice Contains methods for doing math operations that revert on overflow or underflow for minimal gas cost
 library LowGasSafeMath {
-    /// @notice Returns x + y, reverts if sum overflows uint256
-    /// @param x The augend
-    /// @param y The addend
-    /// @return z The sum of x and y
+  /// @notice Returns x + y, reverts if sum overflows uint256
+  /// @param x The augend
+  /// @param y The addend
+  /// @return z The sum of x and y
 
-    // todo: better function name
-    function check(
-        uint256 x,
-        uint256 y,
-        uint256 z
-    ) internal pure returns (bool) {
-        unchecked {
-            return (z = x - y) <= x;
-        }
+  // todo: better function name
+  function check(
+    uint256 x,
+    uint256 y,
+    uint256 z
+  ) internal pure returns (bool) {
+    unchecked {
+      return (z = x - y) <= x;
     }
+  }
 
-    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require((z = x + y) >= x);
+  function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    require((z = x + y) >= x);
 
-        unchecked {
-            return z;
-        }
+    unchecked {
+      return z;
     }
+  }
 
-    /// @notice Returns x - y, reverts if underflows
-    /// @param x The minuend
-    /// @param y The subtrahend
-    /// @return z The difference of x and y
-    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require(check(x, y, z));
+  /// @notice Returns x - y, reverts if underflows
+  /// @param x The minuend
+  /// @param y The subtrahend
+  /// @return z The difference of x and y
+  function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    require(check(x, y, z));
 
-        unchecked {
-            return z;
-        }
+    unchecked {
+      return z;
     }
+  }
 
-    /// @notice Returns x * y, reverts if overflows
-    /// @param x The multiplicand
-    /// @param y The multiplier
-    /// @return z The product of x and y
-    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require(x == 0 || (z = x * y) / x == y);
+  /// @notice Returns x * y, reverts if overflows
+  /// @param x The multiplicand
+  /// @param y The multiplier
+  /// @return z The product of x and y
+  function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+    require(x == 0 || (z = x * y) / x == y);
 
-        unchecked {
-            return z;
-        }
+    unchecked {
+      return z;
     }
+  }
 
-    /// @notice Returns x + y, reverts if overflows or underflows
-    /// @param x The augend
-    /// @param y The addend
-    /// @return z The sum of x and y
-    function add(int256 x, int256 y) internal pure returns (int256 z) {
-        require((z = x + y) >= x == (y >= 0));
+  /// @notice Returns x + y, reverts if overflows or underflows
+  /// @param x The augend
+  /// @param y The addend
+  /// @return z The sum of x and y
+  function add(int256 x, int256 y) internal pure returns (int256 z) {
+    require((z = x + y) >= x == (y >= 0));
 
-        unchecked {
-            return z;
-        }
+    unchecked {
+      return z;
     }
+  }
 
-    /// @notice Returns x - y, reverts if overflows or underflows
-    /// @param x The minuend
-    /// @param y The subtrahend
-    /// @return z The difference of x and y
-    function sub(int256 x, int256 y) internal pure returns (int256 z) {
-        require((z = x - y) <= x == (y >= 0));
+  /// @notice Returns x - y, reverts if overflows or underflows
+  /// @param x The minuend
+  /// @param y The subtrahend
+  /// @return z The difference of x and y
+  function sub(int256 x, int256 y) internal pure returns (int256 z) {
+    require((z = x - y) <= x == (y >= 0));
 
-        unchecked {
-            return z;
-        }
+    unchecked {
+      return z;
     }
+  }
 }

--- a/contracts/utils/NoDelegateCall.sol
+++ b/contracts/utils/NoDelegateCall.sol
@@ -4,24 +4,24 @@ pragma solidity ^0.8.0;
 /// @title Prevents delegatecall to a contract
 /// @notice Base contract that provides a modifier for preventing delegatecall to methods in a child contract
 abstract contract NoDelegateCall {
-    /// @dev The original address of this contract
-    address private immutable original;
+  /// @dev The original address of this contract
+  address private immutable original;
 
-    constructor() {
-        // Immutables are computed in the init code of the contract, and then inlined into the deployed bytecode.
-        // In other words, this variable won't change when it's checked at runtime.
-        original = address(this);
-    }
+  constructor() {
+    // Immutables are computed in the init code of the contract, and then inlined into the deployed bytecode.
+    // In other words, this variable won't change when it's checked at runtime.
+    original = address(this);
+  }
 
-    /// @dev Private method is used instead of inlining into modifier because modifiers are copied into each method,
-    ///     and the use of immutable means the address bytes are copied in every place the modifier is used.
-    function checkNotDelegateCall() private view {
-        require(address(this) == original);
-    }
+  /// @dev Private method is used instead of inlining into modifier because modifiers are copied into each method,
+  ///     and the use of immutable means the address bytes are copied in every place the modifier is used.
+  function checkNotDelegateCall() private view {
+    require(address(this) == original);
+  }
 
-    /// @notice Prevents delegatecall into the modified method
-    modifier noDelegateCall() {
-        checkNotDelegateCall();
-        _;
-    }
+  /// @notice Prevents delegatecall into the modified method
+  modifier noDelegateCall() {
+    checkNotDelegateCall();
+    _;
+  }
 }

--- a/contracts/utils/SafeCast.sol
+++ b/contracts/utils/SafeCast.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title Safe casting methods

--- a/contracts/utils/SqrtPriceMath.sol
+++ b/contracts/utils/SqrtPriceMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 import "./LowGasSafeMath.sol";

--- a/contracts/utils/TickMath.sol
+++ b/contracts/utils/TickMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title Math library for computing sqrt prices from ticks and vice versa

--- a/contracts/utils/TransferHelper.sol
+++ b/contracts/utils/TransferHelper.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 pragma solidity >=0.8.0;
 
 import "../interfaces/IERC20Minimal.sol";
@@ -6,22 +7,19 @@ import "../interfaces/IERC20Minimal.sol";
 /// @title TransferHelper
 /// @notice Contains helper methods for interacting with ERC20 tokens that do not consistently return true/false
 library TransferHelper {
-    /// @notice Transfers tokens from msg.sender to a recipient
-    /// @dev Calls transfer on token contract, errors with TF if transfer fails
-    /// @param token The contract address of the token which will be transferred
-    /// @param to The recipient of the transfer
-    /// @param value The value of the transfer
-    function safeTransfer(
-        address token,
-        address to,
-        uint256 value
-    ) internal {
-        (bool success, bytes memory data) = token.call(
-            abi.encodeWithSelector(IERC20Minimal.transfer.selector, to, value)
-        );
-        require(
-            success && (data.length == 0 || abi.decode(data, (bool))),
-            "TF"
-        );
-    }
+  /// @notice Transfers tokens from msg.sender to a recipient
+  /// @dev Calls transfer on token contract, errors with TF if transfer fails
+  /// @param token The contract address of the token which will be transferred
+  /// @param to The recipient of the transfer
+  /// @param value The value of the transfer
+  function safeTransfer(
+    address token,
+    address to,
+    uint256 value
+  ) internal {
+    (bool success, bytes memory data) = token.call(
+      abi.encodeWithSelector(IERC20Minimal.transfer.selector, to, value)
+    );
+    require(success && (data.length == 0 || abi.decode(data, (bool))), "TF");
+  }
 }

--- a/contracts/utils/UnsafeMath.sol
+++ b/contracts/utils/UnsafeMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 
 /// @title Math functions that do not check inputs or outputs

--- a/contracts/utils/WayRayMath.sol
+++ b/contracts/utils/WayRayMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 pragma solidity ^0.8.0;
 import "./Errors.sol";
 


### PR DESCRIPTION
This PR fixes some test warnings occurring on `main`:

* It adds license declarations to all the `.sol` files missing them
* It removes the `public` visibility modifier from `ChainlinkPricer.constructor`
* It adds the compiler version to some commented-out tests

One warning remains:

```
Warning: This declaration has the same name as another declaration.
  --> contracts/interfaces/amm/IAMMState.sol:72:13:
   |
72 |             uint128 liquidity,
   |             ^^^^^^^^^^^^^^^^^
Note: The other declaration is here:
  --> contracts/interfaces/amm/IAMMState.sol:41:5:
   |
41 |     function liquidity() external view returns (uint128);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Which is caused by the name clash between the `liquidity()` reader and the `liquidity` variable in the tuple returned by `positions()`. Will leave it up to @arturbeg to decide what to do.

Some of the files look more changed than they actually are; I've got prettier enabled so it's reformatting.