### PR TITLE
Refactor & fix math code, to avoid unnecessarily structified data

### DIFF
--- a/contracts/AMM.sol
+++ b/contracts/AMM.sol
@@ -76,13 +76,11 @@ contract AMM is IAMM, Pausable {
   }
 
   modifier onlyFactoryOwner() {
-    require(IFactory(factory).owner() != address(0));
     require(msg.sender == IFactory(factory).owner());
     _;
   }
 
   modifier onlyVAMM() {
-    require(address(vamm) != address(0));
     require(msg.sender == address(vamm));
     _;
   }
@@ -151,14 +149,14 @@ contract AMM is IAMM, Pausable {
     marginEngine.updateTraderMargin(recipient, marginDelta);
   }
 
-  function settlePosition(IMarginEngine.ModifyPositionParams memory params)
+  function settlePosition(IMarginEngine.ModifyPositionParams memory params) // @audit whenNotPaused?
     external
     override
   {
     marginEngine.settlePosition(params);
   }
 
-  function settleTrader(address recipient) external override {
+  function settleTrader(address recipient) external override { // @audit whenNotPaused?
     marginEngine.settleTrader(recipient);
   }
 

--- a/contracts/core_libraries/FixedAndVariableMath.sol
+++ b/contracts/core_libraries/FixedAndVariableMath.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.0;
-import "prb-math/contracts/PRBMathSD59x18Typed.sol";
-import "prb-math/contracts/PRBMathUD60x18Typed.sol";
+import "prb-math/contracts/PRBMathSD59x18.sol";
+import "prb-math/contracts/PRBMathUD60x18.sol";
 import "./Time.sol";
 
 /// @title A utility library for mathematics of fixed and variable token amounts.
@@ -10,11 +10,11 @@ import "./Time.sol";
 library FixedAndVariableMath {
   /// @notice Number of wei-seconds in a year
   /// @dev Ignoring leap years since we're only using it to calculate the eventual APY rate
-  uint256 public constant SECONDS_IN_YEAR = 31536000 * 10**18;
+  uint256 public constant SECONDS_IN_YEAR_IN_WAD = 31536000 * 10**18;
   
   /// @notice One percent
   /// @dev No scary unnamed constants!
-  uint256 internal constant ONE_PERCENT = 10**16;
+  uint256 internal constant ONE_PERCENT_IN_WAD = 10**16;
 
   /// @notice Caclulate the remaining cashflow to settle a position
   /// @param fixedTokenBalance The current balance of the fixed side of the position
@@ -30,41 +30,33 @@ library FixedAndVariableMath {
     uint256 termEndTimestamp,
     uint256 variableFactorToMaturity
   ) external view returns (int256 cashflow) {
-    PRBMath.SD59x18 memory fixedCashflow = PRBMathSD59x18Typed.mul(
-      PRBMath.SD59x18({ value: fixedTokenBalance }),
-      PRBMath.SD59x18({
-        value: int256(fixedFactor(true, termStartTimestamp, termEndTimestamp))
-      })
+    int256 fixedCashflow = PRBMathSD59x18.mul(
+      fixedTokenBalance,
+      int256(fixedFactor(true, termStartTimestamp, termEndTimestamp)));
+
+    int256 variableCashflow = PRBMathSD59x18.mul(
+      variableTokenBalance,
+      int256(variableFactorToMaturity)
     );
 
-    PRBMath.SD59x18 memory variableCashflow = PRBMathSD59x18Typed.mul(
-      PRBMath.SD59x18({ value: variableTokenBalance }),
-      PRBMath.SD59x18({ value: int256(variableFactorToMaturity) })
-    );
-
-    cashflow = PRBMathSD59x18Typed.add(fixedCashflow, variableCashflow).value;
+    cashflow = fixedCashflow + variableCashflow;
   }
 
-  /// @notice Divide a given time in seconds by the number of wei-seconds in a year
-  /// @param timeInSeconds A time in wei-seconds
-  /// @return timeInYears An annualised factor of timeInSeconds
+  /// @notice Divide a given time in seconds by the number of seconds in a year
+  /// @param timeInSecondsAsWad A time in seconds in Wad (i.e. scaled up by 10^18)
+  /// @return timeInYears An annualised factor of timeInSeconds, also in Wad
   ///
   /// #if_succeeds $result > 0;
   /// #if_succeeds old(timeInSeconds) > 0;
-  function accrualFact(uint256 timeInSeconds)
+  function accrualFact(uint256 timeInSecondsAsWad)
     public
     pure
     returns (uint256 timeInYears)
   {
-    timeInYears = PRBMathUD60x18Typed
-      .div(
-        PRBMath.UD60x18({ value: timeInSeconds }),
-        PRBMath.UD60x18({ value: SECONDS_IN_YEAR })
-      )
-      .value;
+    timeInYears = PRBMathUD60x18.div(timeInSecondsAsWad, SECONDS_IN_YEAR_IN_WAD);
   }
 
-  /// @notice Calculate the fixed factor for a position
+  /// @notice Calculate the fixed factor for a position // @audit - explain what this means.
   /// @param atMaturity Whether to calculate the factor at maturity (true), or now (false)
   /// @param termStartTimestamp When does the period of time begin, in wei-seconds
   /// @param termEndTimestamp When does the period of time end, in wei-seconds
@@ -95,24 +87,15 @@ library FixedAndVariableMath {
     uint256 timeInSeconds;
 
     if (atMaturity) {
-      timeInSeconds = PRBMathUD60x18Typed
-        .sub(
-          PRBMath.UD60x18({ value: termEndTimestamp }),
-          PRBMath.UD60x18({ value: termStartTimestamp })
-        )
-        .value;
+      timeInSeconds = termEndTimestamp - termStartTimestamp;
     } else {
       timeInSeconds = Time.blockTimestampScaled() - termStartTimestamp;
     }
 
     uint256 timeInYears = accrualFact(timeInSeconds);
 
-    fixedFactorValue = PRBMathUD60x18Typed
-      .mul(
-        PRBMath.UD60x18({ value: timeInYears }),
-        PRBMath.UD60x18({ value: ONE_PERCENT })
-      )
-      .value;
+    fixedFactorValue = PRBMathUD60x18
+      .mul(timeInYears, ONE_PERCENT_IN_WAD);
   }
 
   /// @notice Calculate the fixed token balance for a position over a timespan
@@ -134,28 +117,20 @@ library FixedAndVariableMath {
     require(termEndTimestamp > termStartTimestamp, "E<=S");
 
     // expected fixed cashflow with unbalanced number of fixed tokens
-    PRBMath.SD59x18 memory exp1 = PRBMathSD59x18Typed.mul(
-      PRBMath.SD59x18({ value: amount0 }),
-      PRBMath.SD59x18({
-        value: int256(fixedFactor(true, termStartTimestamp, termEndTimestamp))
-      })
+    int256 exp1 = PRBMathSD59x18.mul(
+      amount0,
+      int256(fixedFactor(true, termStartTimestamp, termEndTimestamp))
     );
 
     // fixed cashflow  with balanced number of fixed tokens
-    PRBMath.SD59x18 memory numerator = PRBMathSD59x18Typed.sub(
-      exp1,
-      PRBMath.SD59x18({ value: excessBalance })
-    );
+    int256 numerator = exp1 - excessBalance;
 
     // fixed token balance that takes into account acrrued cashflows
-    fixedTokenBalance = PRBMathSD59x18Typed
+    fixedTokenBalance = PRBMathSD59x18
       .div(
         numerator,
-        PRBMath.SD59x18({
-          value: int256(fixedFactor(true, termStartTimestamp, termEndTimestamp))
-        })
-      )
-      .value;
+        int256(fixedFactor(true, termStartTimestamp, termEndTimestamp))
+      );
   }
 
   /// @notice Represent excess values accrued in some period
@@ -181,30 +156,15 @@ library FixedAndVariableMath {
   ) internal view returns (int256) {
     AccruedValues memory accruedValues;
 
-    accruedValues.excessFixedAccruedBalance = PRBMathSD59x18Typed
-      .mul(
-        PRBMath.SD59x18({ value: amount0 }),
-        PRBMath.SD59x18({
-          value: int256(
-            fixedFactor(false, termStartTimestamp, termEndTimestamp)
-          )
-        })
-      )
-      .value;
+    accruedValues.excessFixedAccruedBalance = PRBMathSD59x18
+      .mul(amount0,
+        int256(fixedFactor(false, termStartTimestamp, termEndTimestamp))
+      );
 
-    accruedValues.excessVariableAccruedBalance = PRBMathSD59x18Typed
-      .mul(
-        PRBMath.SD59x18({ value: amount1 }),
-        PRBMath.SD59x18({ value: int256(accruedVariableFactor) })
-      )
-      .value;
+    accruedValues.excessVariableAccruedBalance = PRBMathSD59x18
+      .mul(amount1,int256(accruedVariableFactor));
 
-    accruedValues.excessBalance = PRBMathSD59x18Typed
-      .add(
-        PRBMath.SD59x18({ value: accruedValues.excessFixedAccruedBalance }),
-        PRBMath.SD59x18({ value: accruedValues.excessVariableAccruedBalance })
-      )
-      .value;
+    accruedValues.excessBalance = accruedValues.excessFixedAccruedBalance + accruedValues.excessVariableAccruedBalance;
 
     return accruedValues.excessBalance;
   }

--- a/contracts/interfaces/rate_oracles/IRateOracle.sol
+++ b/contracts/interfaces/rate_oracles/IRateOracle.sol
@@ -4,10 +4,11 @@ pragma solidity ^0.8.0;
 
 interface IRateOracle {
     
+    // @audit May make sense to move this to IAaveRateOracle so we can document it using Aave terminology? Other oracle types may use the same or different ways of tracking values - e.g. not in unity of Ray.
     struct Rate {
-        bool isSet;
-        uint256 timestamp;
-        uint256 rateValue;
+        bool isSet; // @audit - don't think we need this? Non-zero timestamp sufficient check for existence?
+        uint256 timestamp; /// In wei-seconds
+        uint256 rateValue; /// in Ray. A return value of 1e27 (1 Ray) indicates no income since pool creation. A value of 2e27 indicates a 100% yield since pool creation. Etc.
     }
 
      /**

--- a/contracts/rate_oracles/AaveRateOracle.sol
+++ b/contracts/rate_oracles/AaveRateOracle.sol
@@ -24,10 +24,13 @@ contract AaveRateOracle is BaseRateOracle, IAaveRateOracle {
         aaveLendingPool = _aaveLendingPool;
     }
 
+    /// @notice Get the Aave Lending Pool's current normalized income per unit of an underlying asset, in Ray
+    /// @return A return value of 1e27 (1 Ray) indicates no income since pool creation. A value of 2e27 indicates a 100% yield since pool creation. Etc.
     function getReserveNormalizedIncome(address underlying) public view override returns(uint256){
         return aaveLendingPool.getReserveNormalizedIncome(underlying);
     }
 
+    /// @notice Store the Aave Lending Pool's current normalized income per unit of an underlying asset, in Ray
     function updateRate(address underlying) public override {
         
         uint256 result = aaveLendingPool.getReserveNormalizedIncome(underlying);
@@ -41,52 +44,39 @@ contract AaveRateOracle is BaseRateOracle, IAaveRateOracle {
         
     }
     
+    /// @inheritdoc BaseRateOracle
     function getApyFromTo(
         address underlying,
         uint256 from,
         uint256 to
     ) internal view override(BaseRateOracle) returns (uint256 apyFromTo) {
 
-        //  require from to be larger than to
+        require(from < to, 'Misordered dates');
 
         uint256 rateFromTo = getRateFromTo(underlying, from, to);
         
+        // @audit - should we use WadRayMath.rayToWad() (rounds up not down)
         rateFromTo =  rateFromTo / (10 ** (27 - 18)); // convert to wei
-        uint256 timeInSeconds = PRBMathUD60x18Typed.sub(
-
-            PRBMath.UD60x18({
-                value: from
-            }),
-
-            PRBMath.UD60x18({
-                value: to
-            })
-
-        ).value;
+        uint256 timeInSeconds = to - from; // @audit - this is the wimte in seconds wei
 
         uint256 timeInYears = FixedAndVariableMath.accrualFact(timeInSeconds);
 
-        apyFromTo = PRBMathUD60x18Typed.mul(
-
-            PRBMath.UD60x18({
-                value: rateFromTo
-            }),
-
-            PRBMath.UD60x18({
-                value: timeInYears
-            })
-
-        ).value;
+        apyFromTo = PRBMathUD60x18.mul(rateFromTo, timeInYears);
 
     }
     
+    /// @notice Calculates the observed interest returned by the underlying in a given period
+    /// @param underlying The address of an underlying ERC20 token known to this Oracle (e.g. USDC not aaveUSDC)
+    /// @param from The timestamp of the start of the period, in wei-seconds
+    /// @param to The timestamp of the end of the period, in wei-seconds
+    /// @return The "floating rate" expressed in Ray, e.g. 4% is encoded as 0.04*10**27 = 4*10*25
     function getRateFromTo(
         address underlying,
         uint256 from,
         uint256 to
     ) public view override returns (uint256) {
         // note that we have to convert aave index into "floating rate" for
-        // swap calculations, i.e. index 1.04*10**27 corresponds to
+        // swap calculations, e.g. an index multiple of 1.04*10**27 corresponds to
         // 0.04*10**27 = 4*10*25
         IRateOracle.Rate memory rateFrom = rates[underlying][from];
         IRateOracle.Rate memory rateTo = rates[underlying][to];
@@ -94,10 +84,11 @@ contract AaveRateOracle is BaseRateOracle, IAaveRateOracle {
         require(rateTo.isSet, "Oracle doesn not have rateTo");
         return
             WadRayMath.rayDiv(rateTo.rateValue, rateFrom.rateValue).sub(
-                10**27
+                WadRayMath.RAY
             );
     }
 
+    /// @inheritdoc BaseRateOracle
     function variableFactor(bool atMaturity, address underlyingToken, uint256 termStartTimestamp, uint256 termEndTimestamp) public override(BaseRateOracle, IRateOracle) returns(uint256 result) {
 
         IRateOracle.Rate memory rate;
@@ -128,6 +119,7 @@ contract AaveRateOracle is BaseRateOracle, IAaveRateOracle {
             }
         }
 
+        // @audit - should we use WadRayMath.rayToWad() (rounds up not down)
         result = result / (10 ** (27 - 18)); // 18 decimals, AB: is this optimal?
     }
 }


### PR DESCRIPTION
Mostly a refactoring, but also fixes some bugs (e.g. accidentally calculating `logTwapApy ^ 0.00000000000000001`, and doing `from - to` instead of `to - from`).

Also add some natspec doc strings and take out some superflous asserts.

See `@audit` tags for questions where I'd like your input. @arturbeg We should resolve these before merging, and should also consider updating the math in other contracts to use the new patterns defined here, if you're happy with how I've done things.

Looking forward, I'd recommend we implement some user defiend types to find existing and prevent future bugs, but I'll take this conversation to Discord now... 😃 