### PR TITLE
qsp8

### DIFF
--- a/contracts/rate_oracles/OracleBuffer.sol
+++ b/contracts/rate_oracles/OracleBuffer.sol
@@ -101,6 +101,7 @@ library OracleBuffer {
         uint16 next
     ) internal returns (uint16) {
         require(current > 0, "I");
+        require(next < MAX_BUFFER_LENGTH, "buffer limit");
         // no-op if the passed next value isn't greater than the current next value
         if (next <= current) return current;
         // store in each slot to prevent fresh SSTOREs in swaps


### PR DESCRIPTION
add MAX_BUFFER_LENGTH check for next argument in OracleBuffer.grow()