### PR TITLE
Rate oracle fix

### DIFF
--- a/contracts/rate_oracles/AaveRateOracle.sol
+++ b/contracts/rate_oracles/AaveRateOracle.sol
@@ -182,6 +182,7 @@ contract AaveRateOracle is BaseRateOracle, IAaveRateOracle {
             OracleBuffer.Observation memory atOrAfter
         ) = observations.getSurroundingObservations(
                 queriedTime,
+                currentTime,
                 currentValueRay,
                 index,
                 cardinality

--- a/contracts/rate_oracles/OracleBuffer.sol
+++ b/contracts/rate_oracles/OracleBuffer.sol
@@ -161,7 +161,8 @@ library OracleBuffer {
     /// @dev Assumes there is at least 1 initialized observation.
     /// Used by observeSingle() to compute the counterfactual accumulator values as of a given block timestamp.
     /// @param self The stored oracle array
-    /// @param target The timestamp at which the reserved observation should be for. Must be chronologically before time.
+    /// @param target The timestamp at which the reserved observation should be for. Must be chronologically before currentTime.
+    /// @param currentTime The current timestamp, at which currentValue applies.
     /// @param currentValue The current observed value if we were writing a new observation now (semantics may differ for different types of rate oracle)
     /// @param index The index of the observation that was most recently written to the observations array
     /// @param cardinality The number of populated elements in the oracle array
@@ -170,6 +171,7 @@ library OracleBuffer {
     function getSurroundingObservations(
         Observation[MAX_BUFFER_LENGTH] storage self,
         uint32 target,
+        uint32 currentTime,
         uint256 currentValue,
         uint16 index,
         uint16 cardinality
@@ -188,7 +190,7 @@ library OracleBuffer {
                 return (beforeOrAt, atOrAfter);
             } else {
                 // otherwise, we need to transform
-                return (beforeOrAt, observation(target, currentValue));
+                return (beforeOrAt, observation(currentTime, currentValue));
             }
         }
 

--- a/contracts/test/TestRateOracle.sol
+++ b/contracts/test/TestRateOracle.sol
@@ -71,14 +71,6 @@ contract TestRateOracle is AaveRateOracle {
         );
     }
 
-    function testGetRateFromTo(uint256 from, uint256 to)
-        external
-        returns (uint256)
-    {
-        latestRateFromTo = getRateFromTo(from, to);
-        return latestRateFromTo;
-    }
-
     // function testBinarySearch(uint32 target)
     //     external
     //     view
@@ -117,6 +109,7 @@ contract TestRateOracle is AaveRateOracle {
             OracleBuffer.Observation memory atOrAfter
         ) = observations.getSurroundingObservations(
                 target,
+                Time.blockTimestampTruncated(),
                 currentValue,
                 oracleVars.rateIndex,
                 oracleVars.rateCardinality

--- a/tasks/listIrsInstances.ts
+++ b/tasks/listIrsInstances.ts
@@ -12,7 +12,7 @@ task(
   const logs = await factory.queryFilter(factory.filters.IrsInstance());
   const events = logs.map((l) => factory.interface.parseLog(l));
 
-  let csvOutput = `underlyingToken,rateOracle,termStartTimestamp,termEndTimestamp,termStartDate,termEndDate,tickSpacing,marginEngine,VAMM,FCM,yieldBearingProtocolID,historicalAPY`;
+  let csvOutput = `underlyingToken,rateOracle,termStartTimestamp,termEndTimestamp,termStartDate,termEndDate,tickSpacing,marginEngine,VAMM,FCM,yieldBearingProtocolID,lookbackWindowInSeconds,cacheMaxAgeInSeconds,historicalAPY`;
 
   for (const e of events) {
     const a = e.args;
@@ -31,7 +31,9 @@ task(
       "MarginEngine",
       a.marginEngine
     );
+    const secondsAgo = await marginEngine.lookbackWindowInSeconds();
     const historicalAPY = await marginEngine.getHistoricalApyReadOnly();
+    const cacheMaxAgeInSeconds = await marginEngine.cacheMaxAgeInSeconds();
 
     csvOutput += `\n${a.underlyingToken},${
       a.rateOracle
@@ -39,7 +41,7 @@ task(
       a.tickSpacing
     },${a.marginEngine},${a.vamm},${a.fcm},${
       a.yieldBearingProtocolID
-    },${historicalAPY.toString()}`;
+    },${secondsAgo.toString()},${cacheMaxAgeInSeconds.toString()},${historicalAPY.toString()}`;
   }
 
   console.log(csvOutput);

--- a/tasks/listIrsInstances.ts
+++ b/tasks/listIrsInstances.ts
@@ -12,7 +12,7 @@ task(
   const logs = await factory.queryFilter(factory.filters.IrsInstance());
   const events = logs.map((l) => factory.interface.parseLog(l));
 
-  let csvOutput = `underlyingToken,rateOracle,termStartTimestamp,termEndTimestamp,termStartDate,termEndDate,tickSpacing,marginEngine,VAMM,FCM,yieldBearingProtocolID`;
+  let csvOutput = `underlyingToken,rateOracle,termStartTimestamp,termEndTimestamp,termStartDate,termEndDate,tickSpacing,marginEngine,VAMM,FCM,yieldBearingProtocolID,historicalAPY`;
 
   for (const e of events) {
     const a = e.args;
@@ -27,7 +27,19 @@ task(
     const startTimeString = new Date(startTimestamp * 1000).toISOString();
     const endTImeString = new Date(endTimestamp * 1000).toISOString();
 
-    csvOutput += `\n${a.underlyingToken},${a.rateOracle},${startTimestamp},${endTimestamp},${startTimeString},${endTImeString},${a.tickSpacing},${a.marginEngine},${a.vamm},${a.fcm},${a.yieldBearingProtocolID}`;
+    const marginEngine = await hre.ethers.getContractAt(
+      "MarginEngine",
+      a.marginEngine
+    );
+    const historicalAPY = await marginEngine.getHistoricalApyReadOnly();
+
+    csvOutput += `\n${a.underlyingToken},${
+      a.rateOracle
+    },${startTimestamp},${endTimestamp},${startTimeString},${endTImeString},${
+      a.tickSpacing
+    },${a.marginEngine},${a.vamm},${a.fcm},${
+      a.yieldBearingProtocolID
+    },${historicalAPY.toString()}`;
   }
 
   console.log(csvOutput);

--- a/tasks/rateOracle.ts
+++ b/tasks/rateOracle.ts
@@ -2,18 +2,36 @@ import { task } from "hardhat/config";
 import { utils } from "ethers";
 import { BaseRateOracle } from "../typechain";
 
+function isAddress(address: string): boolean {
+  try {
+    utils.getAddress(address);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}
+
 task(
   "writeRateOracle",
   "Writes a new datapoint for a named rate oracle instance"
 )
   .addParam(
     "rateOracle",
-    "The name of the rate oracle as defined in deployments/<network> (e.g. 'AaveRateOracle_USDT'"
+    "The address of a rate oracle, or the name of the rate oracle as defined in deployments/<network> (e.g. 'AaveRateOracle_USDT'"
   )
   .setAction(async (taskArgs, hre) => {
-    const rateOracle = (await hre.ethers.getContract(
-      taskArgs.rateOracle
-    )) as BaseRateOracle;
+    let rateOracle;
+    if (isAddress(taskArgs.rateOracle)) {
+      rateOracle = (await hre.ethers.getContractAt(
+        "BaseRateOracle",
+        taskArgs.rateOracle
+      )) as BaseRateOracle;
+    } else {
+      rateOracle = (await hre.ethers.getContract(
+        taskArgs.rateOracle
+      )) as BaseRateOracle;
+    }
+
     // console.log(`Listing Rates known by Rate Oracle ${rateOracle.address}`);
 
     const trx = await rateOracle.writeOracleEntry();
@@ -26,12 +44,20 @@ task(
 )
   .addParam(
     "rateOracle",
-    "The name of the rate oracle as defined in deployments/<network> (e.g. 'AaveRateOracle_USDT'"
+    "The address of a rate oracle, or the name of the rate oracle as defined in deployments/<network> (e.g. 'AaveRateOracle_USDT'"
   )
   .setAction(async (taskArgs, hre) => {
-    const rateOracle = (await hre.ethers.getContract(
-      taskArgs.rateOracle
-    )) as BaseRateOracle;
+    let rateOracle;
+    if (isAddress(taskArgs.rateOracle)) {
+      rateOracle = (await hre.ethers.getContractAt(
+        "BaseRateOracle",
+        taskArgs.rateOracle
+      )) as BaseRateOracle;
+    } else {
+      rateOracle = (await hre.ethers.getContract(
+        taskArgs.rateOracle
+      )) as BaseRateOracle;
+    }
     // console.log(`Listing Rates known by Rate Oracle ${rateOracle.address}`);
 
     const oracleVars = await rateOracle.oracleVars();


### PR DESCRIPTION
When getting the rate or APY for a period that starts after the last observation, we were returning zero.

This is because we were incorrectly "finding" the current value from Aave with two different timestamps, and interpolating between those two values to get zero.

Next steps for @arturbeg / @0xZenus :
 - review and merge this change
 - redeploy to kovan  ASAP (`npm run deploy:kovan` - happy to help if you hit issues)
 - create a new IRS instance on kovan (`npx hardhat createIrsInstance --network kovan ...`), but note that it won't work properly until `lookbackWindowInSeconds` seconds (6 hours) have elpased since the fixed rate oracle was deployed
 - do something to bug bounty to make sure no one tries to claim $100k for this bug
 - resume testing the UI on top of new kovan contracts (again, after 6 hours)