### PR TITLE
LP Caps

### DIFF
--- a/contracts/MarginEngine.sol
+++ b/contracts/MarginEngine.sol
@@ -512,7 +512,6 @@ contract MarginEngine is
 
         (
             bool _isLiquidatable,
-            int256 _marginRequirement
         ) = _isLiquidatablePosition(_position, _tickLower, _tickUpper);
 
         if (!_isLiquidatable) {

--- a/contracts/VAMM.sol
+++ b/contracts/VAMM.sol
@@ -50,6 +50,17 @@ contract VAMM is VAMMStorage, IVAMM, Initializable, OwnableUpgradeable, Pausable
     _;
   }
 
+  modifier checkIsAlpha() {
+    
+    if (_isAlpha) {
+      IPeriphery _periphery = _factory.periphery();
+      require(msg.sender==address(_periphery), "periphery only");
+    }
+
+    _;
+    
+  }
+
   // https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor () initializer {}
@@ -213,12 +224,13 @@ contract VAMM is VAMMStorage, IVAMM, Initializable, OwnableUpgradeable, Pausable
 
   }
 
+  // todo: prevent burning directly via the vamm if in Alpha State
   function burn(
     address recipient,
     int24 tickLower,
     int24 tickUpper,
     uint128 amount
-  ) external override whenNotPaused lock returns(int256 positionMarginRequirement) {
+  ) external override checkIsAlpha whenNotPaused lock returns(int256 positionMarginRequirement) {
 
     /// @dev if msg.sender is the MarginEngine, it is a burn induced by a position liquidation
 
@@ -338,12 +350,7 @@ contract VAMM is VAMMStorage, IVAMM, Initializable, OwnableUpgradeable, Pausable
     int24 tickLower,
     int24 tickUpper,
     uint128 amount
-  ) external override whenNotPaused checkCurrentTimestampTermEndTimestampDelta lock returns(int256 positionMarginRequirement) {
-
-    if (_isAlpha) {
-      IPeriphery _periphery = _factory.periphery();
-      require(msg.sender==address(_periphery), "periphery only");
-    }
+  ) external override checkIsAlpha whenNotPaused checkCurrentTimestampTermEndTimestampDelta lock returns(int256 positionMarginRequirement) {
     
     /// might be helpful to have a higher level peripheral function for minting a given amount given a certain amount of notional an LP wants to support
 

--- a/contracts/VAMM.sol
+++ b/contracts/VAMM.sol
@@ -203,6 +203,16 @@ contract VAMM is VAMMStorage, IVAMM, Initializable, OwnableUpgradeable, Pausable
     emit Fee(_feeWad);
   }
 
+  
+  /// @inheritdoc IVAMM
+  function setIsAlpha(bool __isAlpha) external override onlyOwner {
+
+    require(_isAlpha != __isAlpha, "alpha state already set");
+    _isAlpha = __isAlpha;
+    emit IsAlpha(_isAlpha);
+
+  }
+
   function burn(
     address recipient,
     int24 tickLower,

--- a/contracts/VAMM.sol
+++ b/contracts/VAMM.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.9;
 import "./core_libraries/Tick.sol";
 import "./storage/VAMMStorage.sol";
 import "./interfaces/IVAMM.sol";
+import "./interfaces/IPeriphery.sol";
 import "./core_libraries/TickBitmap.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "./utils/SqrtPriceMath.sol";
@@ -329,6 +330,11 @@ contract VAMM is VAMMStorage, IVAMM, Initializable, OwnableUpgradeable, Pausable
     uint128 amount
   ) external override whenNotPaused checkCurrentTimestampTermEndTimestampDelta lock returns(int256 positionMarginRequirement) {
 
+    if (_isAlpha) {
+      IPeriphery _periphery = _factory.periphery();
+      require(msg.sender==address(_periphery), "periphery only");
+    }
+    
     /// might be helpful to have a higher level peripheral function for minting a given amount given a certain amount of notional an LP wants to support
 
     if (amount <= 0) {

--- a/contracts/VAMM.sol
+++ b/contracts/VAMM.sol
@@ -139,6 +139,10 @@ contract VAMM is VAMMStorage, IVAMM, Initializable, OwnableUpgradeable, Pausable
       return _vammVars;
   }
 
+  /// @inheritdoc IVAMM
+  function isAlpha() external view override returns (bool) {
+    return _isAlpha;
+  }
 
   /// @dev modifier that ensures the
   modifier onlyMarginEngine () {

--- a/contracts/interfaces/IPeriphery.sol
+++ b/contracts/interfaces/IPeriphery.sol
@@ -7,14 +7,13 @@ import "../interfaces/IVAMM.sol";
 import "contracts/utils/CustomErrors.sol";
 
 interface IPeriphery is CustomErrors {
-    
     // events
 
     /// @dev emitted after new lp notional cap is set
-    event NotionalCap(uint256 _lpNotionalCapNew);
-    
+    event NotionalCap(IMarginEngine _marginEngine, uint256 _lpNotionalCapNew);
+
     // structs
-    
+
     struct MintOrBurnParams {
         IMarginEngine marginEngine;
         int24 tickLower;
@@ -41,8 +40,10 @@ interface IPeriphery is CustomErrors {
         view
         returns (int24 currentTick);
 
+
+    /// @param _marginEngine MarginEngine for which to get the lp cap in underlying tokens
     /// @return Notional Cap for liquidity providers that mint via periphery (enforced in the core if isAlpha is set to true)
-    function lpNotionalCap() external returns (uint256);
+    function lpNotionalCaps(IMarginEngine _marginEngine) external returns (uint256);
 
     // non-view functions
 

--- a/contracts/interfaces/IPeriphery.sol
+++ b/contracts/interfaces/IPeriphery.sol
@@ -46,6 +46,13 @@ interface IPeriphery is CustomErrors {
         external
         returns (uint256);
 
+    /// @param _marginEngine MarginEngine for which to get the lp notional cumulative in underlying tokens
+    /// @return Total amount of notional supplied by the LPs to a given _marginEngine via the periphery
+    function lpNotionalCumulatives(IMarginEngine _marginEngine)
+        external
+        returns (uint256);
+
+
     // non-view functions
 
     function mintOrBurn(MintOrBurnParams memory params)

--- a/contracts/interfaces/IPeriphery.sol
+++ b/contracts/interfaces/IPeriphery.sol
@@ -7,6 +7,14 @@ import "../interfaces/IVAMM.sol";
 import "contracts/utils/CustomErrors.sol";
 
 interface IPeriphery is CustomErrors {
+    
+    // events
+
+    /// @dev emitted after new lp notional cap is set
+    event NotionalCap(uint256 _lpNotionalCapNew);
+    
+    // structs
+    
     struct MintOrBurnParams {
         IMarginEngine marginEngine;
         int24 tickLower;
@@ -32,6 +40,9 @@ interface IPeriphery is CustomErrors {
         external
         view
         returns (int24 currentTick);
+
+    /// @return Notional Cap for liquidity providers that mint via periphery (enforced in the core if isAlpha is set to true)
+    function lpNotionalCap() external returns (uint256);
 
     // non-view functions
 

--- a/contracts/interfaces/IPeriphery.sol
+++ b/contracts/interfaces/IPeriphery.sol
@@ -40,10 +40,11 @@ interface IPeriphery is CustomErrors {
         view
         returns (int24 currentTick);
 
-
     /// @param _marginEngine MarginEngine for which to get the lp cap in underlying tokens
     /// @return Notional Cap for liquidity providers that mint via periphery (enforced in the core if isAlpha is set to true)
-    function lpNotionalCaps(IMarginEngine _marginEngine) external returns (uint256);
+    function lpNotionalCaps(IMarginEngine _marginEngine)
+        external
+        returns (uint256);
 
     // non-view functions
 

--- a/contracts/interfaces/IPeriphery.sol
+++ b/contracts/interfaces/IPeriphery.sol
@@ -52,7 +52,6 @@ interface IPeriphery is CustomErrors {
         external
         returns (uint256);
 
-
     // non-view functions
 
     function mintOrBurn(MintOrBurnParams memory params)

--- a/contracts/interfaces/IPeriphery.sol
+++ b/contracts/interfaces/IPeriphery.sol
@@ -41,7 +41,7 @@ interface IPeriphery is CustomErrors {
         returns (int24 currentTick);
 
     /// @param _marginEngine MarginEngine for which to get the lp cap in underlying tokens
-    /// @return Notional Cap for liquidity providers that mint via periphery (enforced in the core if isAlpha is set to true)
+    /// @return Notional Cap for liquidity providers that mint or burn via periphery (enforced in the core if isAlpha is set to true)
     function lpNotionalCaps(IMarginEngine _marginEngine)
         external
         returns (uint256);

--- a/contracts/interfaces/IVAMM.sol
+++ b/contracts/interfaces/IVAMM.sol
@@ -46,6 +46,12 @@ interface IVAMM is IPositionStructs, CustomErrors {
     /// @dev emitted after fee is set
     event Fee(uint256 feeWad);
 
+    /// @dev emitted after the _isAlpha boolean is updated by the owner of the VAMM
+    /// @dev _isAlpha boolean dictates whether the Margin Engine is in the Alpha State, i.e. mints can only be done via the periphery
+    /// @dev additionally, the periphery has the logic to take care of lp notional caps in the Alpha State phase of VAMM
+    /// @dev __isAlpha is the newly set value for the _isAlpha boolean
+    event IsAlpha(bool __isAlpha);
+
     // structs
 
     struct VAMMVars {
@@ -192,6 +198,11 @@ interface IVAMM is IPositionStructs, CustomErrors {
     /// @dev the current protocol fee as a percentage of the swap fee taken on withdrawal
     // represented as an integer denominator (1/x)
     function setFeeProtocol(uint8 feeProtocol) external;
+
+    /// @notice Function that sets the _isAlpha state variable, if it is set to true the protocol is in the Alpha State
+    /// @dev if the VAMM is at the alpha state, mints can only be done via the periphery which in turn takes care of notional caps for the LPs
+    /// @dev this function can only be called by the owner of the VAMM
+    function setIsAlpha(bool __isAlpha) external;
 
     /// @notice Function that sets fee of the vamm
     /// @dev The vamm's fee (proportion) in wad

--- a/contracts/interfaces/IVAMM.sol
+++ b/contracts/interfaces/IVAMM.sol
@@ -162,6 +162,9 @@ interface IVAMM is IPositionStructs, CustomErrors {
     /// @return The current VAMM Vars (see struct definition for semantics)
     function vammVars() external view returns (VAMMVars memory);
 
+    /// @return If true, the VAMM Proxy is currently in alpha state, hence minting can only be done via the periphery. If false, minting can be done directly via VAMM.
+    function isAlpha() external view returns (bool);
+
     /// @notice The fixed token growth accumulated per unit of liquidity for the entire life of the vamm
     /// @dev This value can overflow the uint256
     function fixedTokenGrowthGlobalX128() external view returns (int256);

--- a/contracts/periphery/Periphery.sol
+++ b/contracts/periphery/Periphery.sol
@@ -26,13 +26,17 @@ contract Periphery is IPeriphery {
 
     modifier marginEngineOwnerOnly(IMarginEngine _marginEngine) {
         require(address(_marginEngine) != address(0), "me addr zero");
-        address marginEngineOwner = OwnableUpgradeable(address(_marginEngine)).owner();
-        require(msg.sender == marginEngineOwner, "only me owner"); 
-        _;   
+        address marginEngineOwner = OwnableUpgradeable(address(_marginEngine))
+            .owner();
+        require(msg.sender == marginEngineOwner, "only me owner");
+        _;
     }
 
-    function setLPNotionalCap(IMarginEngine _marginEngine, uint256 _lpNotionalCapNew) external marginEngineOwnerOnly(_marginEngine)  {
-        if (lpNotionalCaps[_marginEngine] != _lpNotionalCapNew) { 
+    function setLPNotionalCap(
+        IMarginEngine _marginEngine,
+        uint256 _lpNotionalCapNew
+    ) external marginEngineOwnerOnly(_marginEngine) {
+        if (lpNotionalCaps[_marginEngine] != _lpNotionalCapNew) {
             lpNotionalCaps[_marginEngine] = _lpNotionalCapNew;
             emit NotionalCap(_marginEngine, lpNotionalCaps[_marginEngine]);
         }

--- a/contracts/periphery/Periphery.sol
+++ b/contracts/periphery/Periphery.sol
@@ -38,24 +38,28 @@ contract Periphery is IPeriphery {
         _;
     }
 
-    modifier checkLPNotionalCap(IMarginEngine _marginEngine, uint256 _notionalDelta, bool _isMint) {
-        
-        uint256 _lpNotionalCap = lpNotionalCaps[_marginEngine]; 
+    modifier checkLPNotionalCap(
+        IMarginEngine _marginEngine,
+        uint256 _notionalDelta,
+        bool _isMint
+    ) {
+        uint256 _lpNotionalCap = lpNotionalCaps[_marginEngine];
 
         if (_isMint) {
             lpNotionalCumulatives[_marginEngine] += _notionalDelta;
 
             if (_lpNotionalCap > 0) {
                 /// @dev if > 0 the cap assumed to have been set, if == 0 assume no cap by convention
-                require(lpNotionalCumulatives[_marginEngine] < _lpNotionalCap, "lp cap limit");
+                require(
+                    lpNotionalCumulatives[_marginEngine] < _lpNotionalCap,
+                    "lp cap limit"
+                );
             }
-        }
-        else {
+        } else {
             lpNotionalCumulatives[_marginEngine] -= _notionalDelta;
         }
 
         _;
-        
     }
 
     function setLPNotionalCap(

--- a/contracts/periphery/Periphery.sol
+++ b/contracts/periphery/Periphery.sol
@@ -22,7 +22,12 @@ contract Periphery is IPeriphery {
     using SafeTransferLib for IERC20Minimal;
 
     /// @dev Voltz Protocol marginEngine => LP Notional Cap in Underlying Tokens
+    /// @inheritdoc IPeriphery
     mapping(IMarginEngine => uint256) public override lpNotionalCaps;
+
+    /// @dev amount of notional (coming from the periphery) in terms of underlying tokens taken up by LPs in a given MarginEngine
+    /// @inheritdoc IPeriphery
+    mapping(IMarginEngine => uint256) public override lpNotionalCumulatives;
 
     modifier marginEngineOwnerOnly(IMarginEngine _marginEngine) {
         require(address(_marginEngine) != address(0), "me addr zero");

--- a/contracts/periphery/Periphery.sol
+++ b/contracts/periphery/Periphery.sol
@@ -19,6 +19,24 @@ contract Periphery is IPeriphery {
     using SafeCast for int256;
 
     using SafeTransferLib for IERC20Minimal;
+    
+    /// @inheritdoc IPeriphery
+    uint256 lpNotionalCap public override;
+
+
+    modifier marginEngineOwnerOnly(IMarginEngine _marginEngine) {
+        require(address(_marginEngine) != address(0), "me addr zero");
+        address marginEngineOwner = _marginEngine.owner(); 
+        require(msg.sender == marginEngineOwner, "only me owner"); 
+        _;   
+    }
+
+    function setLPNotionalCap(IMarginEngine _marginEngine, uint256 _lpNotionalCapNew) external marginEngineOwnerOnly(_marginEngine)  {
+        if (lpNotionalCap != _lpNotionalCapNew) { 
+            lpNotionalCap = _lpNotionalCapNew;
+            emit NotionalCap(lpNotionalCap);
+        }
+    }
 
     function updatePositionMargin(
         IMarginEngine _marginEngine,

--- a/contracts/periphery/Periphery.sol
+++ b/contracts/periphery/Periphery.sol
@@ -13,28 +13,28 @@ import "hardhat/console.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "../core_libraries/SafeTransferLib.sol";
 import "../core_libraries/Tick.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 contract Periphery is IPeriphery {
     using SafeCast for uint256;
     using SafeCast for int256;
 
     using SafeTransferLib for IERC20Minimal;
-    
-    /// @inheritdoc IPeriphery
-    uint256 lpNotionalCap public override;
 
+    /// @dev Voltz Protocol marginEngine => LP Notional Cap in Underlying Tokens
+    mapping(IMarginEngine => uint256) public override lpNotionalCaps;
 
     modifier marginEngineOwnerOnly(IMarginEngine _marginEngine) {
         require(address(_marginEngine) != address(0), "me addr zero");
-        address marginEngineOwner = _marginEngine.owner(); 
+        address marginEngineOwner = OwnableUpgradeable(address(_marginEngine)).owner();
         require(msg.sender == marginEngineOwner, "only me owner"); 
         _;   
     }
 
     function setLPNotionalCap(IMarginEngine _marginEngine, uint256 _lpNotionalCapNew) external marginEngineOwnerOnly(_marginEngine)  {
-        if (lpNotionalCap != _lpNotionalCapNew) { 
-            lpNotionalCap = _lpNotionalCapNew;
-            emit NotionalCap(lpNotionalCap);
+        if (lpNotionalCaps[_marginEngine] != _lpNotionalCapNew) { 
+            lpNotionalCaps[_marginEngine] = _lpNotionalCapNew;
+            emit NotionalCap(_marginEngine, lpNotionalCaps[_marginEngine]);
         }
     }
 

--- a/contracts/storage/VAMMStorage.sol
+++ b/contracts/storage/VAMMStorage.sol
@@ -31,6 +31,7 @@ contract VAMMStorageV1 {
     mapping(int24 => Tick.Info) internal _ticks;
     mapping(int16 => uint256) internal _tickBitmap;
     IVAMM.VAMMVars internal _vammVars;
+    bool internal _isAlpha;
 }
 
 contract VAMMStorage is VAMMStorageV1 {

--- a/test/periphery/periphery.ts
+++ b/test/periphery/periphery.ts
@@ -112,6 +112,19 @@ describe("Periphery", async () => {
       .approve(periphery.address, BigNumber.from(10).pow(27));
   });
 
+  it("set lp notional cap works as expected", async () => {
+
+    await expect(
+      periphery.setLPNotionalCap(marginEngineTest.address, toBn("10"))
+    ).to.emit(periphery, "NotionalCap")
+    .withArgs(
+      marginEngineTest.address,
+      toBn("10")
+    );
+
+  })
+
+
   it("swap quoter on revert: margin requirement not met", async () => {
     // await factory.connect(wallet).setApproval(periphery.address, true);
     // await factory.connect(other).setApproval(periphery.address, true);

--- a/test/periphery/periphery.ts
+++ b/test/periphery/periphery.ts
@@ -185,7 +185,11 @@ describe("Periphery", async () => {
     ).to.not.be.reverted;
   });
 
-  it("can't mint with vamm when alpha but can mint with periphery", async () => {});
+  it("can't mint with vamm when alpha but can mint with periphery", async () => {
+
+
+
+  });
 
   it("swap quoter on revert: margin requirement not met", async () => {
     await vammTest.initializeVAMM(encodeSqrtRatioX96(1, 1).toString());

--- a/test/periphery/periphery.ts
+++ b/test/periphery/periphery.ts
@@ -202,13 +202,22 @@ describe("Periphery", async () => {
     );
   });
 
-  it("can't mint with vamm when alpha but can mint with periphery", async () => {
+  it("can't mint or burn with vamm when alpha but can mint with periphery", async () => {
     await vammTest.setIsAlpha(true);
 
     await vammTest.initializeVAMM(encodeSqrtRatioX96(1, 1).toString());
 
     await expect(
       vammTest.mint(
+        wallet.address,
+        -TICK_SPACING,
+        TICK_SPACING,
+        toBn("10000000")
+      )
+    ).to.be.revertedWith("periphery only");
+
+    await expect(
+      vammTest.burn(
         wallet.address,
         -TICK_SPACING,
         TICK_SPACING,

--- a/test/periphery/periphery.ts
+++ b/test/periphery/periphery.ts
@@ -113,17 +113,12 @@ describe("Periphery", async () => {
   });
 
   it("set lp notional cap works as expected", async () => {
-
     await expect(
       periphery.setLPNotionalCap(marginEngineTest.address, toBn("10"))
-    ).to.emit(periphery, "NotionalCap")
-    .withArgs(
-      marginEngineTest.address,
-      toBn("10")
-    );
-
-  })
-
+    )
+      .to.emit(periphery, "NotionalCap")
+      .withArgs(marginEngineTest.address, toBn("10"));
+  });
 
   it("swap quoter on revert: margin requirement not met", async () => {
     // await factory.connect(wallet).setApproval(periphery.address, true);


### PR DESCRIPTION
Notion Ticket: https://www.notion.so/voltz/Capped-launch-f6ec4aa77e2f42e1bdc02be4ff54dcf7

Changes introduced include:

- introduced _isAlpha storage boolean that tells if a given VAMM is in an alpha state, if it is in an alpha state then it means that mints will only be possible via the peripheral module. This is done in order to do liquidity provider notional cap accounting and extra logic in the Periphery rather than in the core.
- lp notional caps in terms of underlying tokens are settable by the margin engine owners
- before a mint is conducted via the periphery, a modifier is invoked to update the cumulative notional of liquidity provided by LPs and check if the updated cumulative value exceeds the cap, if it does then it reverts, meaning lp deposits beyond the cap are impossible