### PR TITLE
refactor: change package name @voltz/voltz-core in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "voltz-core",
+  "name": "@voltz/voltz-core",
   "engines": {
     "node": ">=16.0.0"
   },


### PR DESCRIPTION
Make this consistent with the names of the remaining npm packages we need to publish under the name @voltz 