### PR TITLE
refactor: change npm package name from @voltz to @voltz-protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@voltz/voltz-core",
+  "name": "@voltz-protocol/voltz-core",
   "engines": {
     "node": ">=16.0.0"
   },


### PR DESCRIPTION
Same reason as PR 32 for v1-sdk 