### PR TITLE
Fix notional cap

### DIFF
--- a/contracts/interfaces/IPeriphery.sol
+++ b/contracts/interfaces/IPeriphery.sol
@@ -10,7 +10,7 @@ interface IPeriphery is CustomErrors {
     // events
 
     /// @dev emitted after new lp notional cap is set
-    event NotionalCap(IMarginEngine _marginEngine, uint256 _lpNotionalCapNew);
+    event NotionalCap(IVAMM _vamm, uint256 _lpNotionalCapNew);
 
     // structs
 
@@ -40,17 +40,13 @@ interface IPeriphery is CustomErrors {
         view
         returns (int24 currentTick);
 
-    /// @param _marginEngine MarginEngine for which to get the lp cap in underlying tokens
+    /// @param _vamm VAMM for which to get the lp cap in underlying tokens
     /// @return Notional Cap for liquidity providers that mint or burn via periphery (enforced in the core if isAlpha is set to true)
-    function lpNotionalCaps(IMarginEngine _marginEngine)
-        external
-        returns (uint256);
+    function lpNotionalCaps(IVAMM _vamm) external returns (uint256);
 
-    /// @param _marginEngine MarginEngine for which to get the lp notional cumulative in underlying tokens
-    /// @return Total amount of notional supplied by the LPs to a given _marginEngine via the periphery
-    function lpNotionalCumulatives(IMarginEngine _marginEngine)
-        external
-        returns (uint256);
+    /// @param _vamm VAMM for which to get the lp notional cumulative in underlying tokens
+    /// @return Total amount of notional supplied by the LPs to a given VAMM via the periphery
+    function lpNotionalCumulatives(IVAMM _vamm) external returns (uint256);
 
     // non-view functions
 

--- a/test/periphery/periphery.ts
+++ b/test/periphery/periphery.ts
@@ -113,11 +113,9 @@ describe("Periphery", async () => {
   });
 
   it("set lp notional cap works as expected with margin engine owner", async () => {
-    await expect(
-      periphery.setLPNotionalCap(marginEngineTest.address, toBn("10"))
-    )
+    await expect(periphery.setLPNotionalCap(vammTest.address, toBn("10")))
       .to.emit(periphery, "NotionalCap")
-      .withArgs(marginEngineTest.address, toBn("10"));
+      .withArgs(vammTest.address, toBn("10"));
   });
 
   it("set lp notional reverts if invoked by a non-owner", async () => {
@@ -129,7 +127,7 @@ describe("Periphery", async () => {
   });
 
   it("check can't mint beyond the notional cap", async () => {
-    await periphery.setLPNotionalCap(marginEngineTest.address, toBn("10"));
+    await periphery.setLPNotionalCap(vammTest.address, toBn("10"));
 
     await periphery.mintOrBurn({
       marginEngine: marginEngineTest.address,


### PR DESCRIPTION
Cap can be circumvented with fake MarginEngine, so index cap on VAMM address not MarginEngine address to avoid this.