### PR TITLE
fix: margin withdrawal from non-eth pools

### DIFF
--- a/contracts/periphery/Periphery.sol
+++ b/contracts/periphery/Periphery.sol
@@ -176,10 +176,16 @@ contract Periphery is IPeriphery {
 
         // if WETH pools, accept deposit only in ETH
         if (address(underlyingToken) == address(_weth)) {
-            require(marginDelta <= 0, "Invalid: cannot deposit wETH to this pool");
+            require(
+                marginDelta <= 0,
+                "Invalid: cannot deposit wETH to this pool"
+            );
 
             if (marginDelta < 0) {
-                require(msg.value == 0, "Invalid: cannot deposit ETH while withdrawing wETH");
+                require(
+                    msg.value == 0,
+                    "Invalid: cannot deposit ETH while withdrawing wETH"
+                );
                 marginEngine.updatePositionMargin(
                     msg.sender,
                     tickLower,

--- a/contracts/periphery/Periphery.sol
+++ b/contracts/periphery/Periphery.sol
@@ -176,10 +176,10 @@ contract Periphery is IPeriphery {
 
         // if WETH pools, accept deposit only in ETH
         if (address(underlyingToken) == address(_weth)) {
-            require(marginDelta <= 0, "INV");
+            require(marginDelta <= 0, "Invalid: cannot deposit wETH to this pool");
 
             if (marginDelta < 0) {
-                require(msg.value == 0, "INV");
+                require(msg.value == 0, "Invalid: cannot deposit ETH while withdrawing wETH");
                 marginEngine.updatePositionMargin(
                     msg.sender,
                     tickLower,
@@ -213,14 +213,14 @@ contract Periphery is IPeriphery {
                     address(marginEngine),
                     marginDelta.toUint256()
                 );
-
-                marginEngine.updatePositionMargin(
-                    msg.sender,
-                    tickLower,
-                    tickUpper,
-                    marginDelta
-                );
             }
+
+            marginEngine.updatePositionMargin(
+                msg.sender,
+                tickLower,
+                tickUpper,
+                marginDelta
+            );
         }
 
         position = marginEngine.getPosition(msg.sender, tickLower, tickUpper);

--- a/contracts/periphery/Periphery.sol
+++ b/contracts/periphery/Periphery.sol
@@ -176,16 +176,9 @@ contract Periphery is IPeriphery {
 
         // if WETH pools, accept deposit only in ETH
         if (address(underlyingToken) == address(_weth)) {
-            require(
-                marginDelta <= 0,
-                "Invalid: cannot deposit wETH to this pool"
-            );
+            require(marginDelta <= 0, "INV");
 
-            if (marginDelta < 0) {
-                require(
-                    msg.value == 0,
-                    "Invalid: cannot deposit ETH while withdrawing wETH"
-                );
+            if (marginDelta < 0) {require(msg.value == 0, "INV");
                 marginEngine.updatePositionMargin(
                     msg.sender,
                     tickLower,


### PR DESCRIPTION
Margin withdrawal now work for ERC20 pools. 
Before only ETH pool margin withdrawals worked. 