### PR TITLE
Add LP and trader rollover functions w/ tests

### DIFF
--- a/contracts/periphery/Periphery.sol
+++ b/contracts/periphery/Periphery.sol
@@ -99,6 +99,12 @@ contract Periphery is IPeriphery {
         _lpMarginCumulatives[vamm] = lpMarginCumulative;
     }
 
+    function ethToWeth() public payable returns (uint256 wethAmount) {
+        _weth.deposit{value: msg.value}();
+
+        wethAmount = msg.value;
+    }
+
     function accountLPMarginCap(
         IVAMM vamm,
         bytes32 encodedPosition,
@@ -131,7 +137,7 @@ contract Periphery is IPeriphery {
         address owner,
         int24 tickLower,
         int24 tickUpper
-    ) external override {
+    ) public override {
         marginEngine.settlePosition(owner, tickLower, tickUpper);
 
         updatePositionMargin(marginEngine, tickLower, tickUpper, 0, true); // fully withdraw
@@ -174,11 +180,8 @@ contract Periphery is IPeriphery {
             marginDelta = -position.margin;
         }
 
-        // if WETH pools, accept deposit only in ETH
         if (address(underlyingToken) == address(_weth)) {
-            require(marginDelta <= 0, "INV");
-
-            if (marginDelta < 0) {require(msg.value == 0, "INV");
+            if (marginDelta < 0) {
                 marginEngine.updatePositionMargin(
                     msg.sender,
                     tickLower,
@@ -186,20 +189,30 @@ contract Periphery is IPeriphery {
                     marginDelta
                 );
             } else {
-                if (msg.value > 0) {
-                    uint256 ethPassed = msg.value;
-
-                    _weth.deposit{value: msg.value}();
-
-                    underlyingToken.approve(address(marginEngine), ethPassed);
-
-                    marginEngine.updatePositionMargin(
+                if (marginDelta > 0) {
+                    underlyingToken.safeTransferFrom(
                         msg.sender,
-                        tickLower,
-                        tickUpper,
-                        ethPassed.toInt256()
+                        address(this),
+                        marginDelta.toUint256()
                     );
                 }
+
+                if (msg.value > 0) {
+                    _weth.deposit{value: msg.value}();
+                    marginDelta += msg.value.toInt256();
+                }
+                
+                underlyingToken.approve(
+                    address(marginEngine),
+                    marginDelta.toUint256()
+                );
+
+                marginEngine.updatePositionMargin(
+                    msg.sender,
+                    tickLower,
+                    tickUpper,
+                    marginDelta
+                );
             }
         } else {
             if (marginDelta > 0) {
@@ -211,6 +224,20 @@ contract Periphery is IPeriphery {
                 underlyingToken.approve(
                     address(marginEngine),
                     marginDelta.toUint256()
+                );
+
+                marginEngine.updatePositionMargin(
+                    msg.sender,
+                    tickLower,
+                    tickUpper,
+                    marginDelta
+                );
+            } else {
+                marginEngine.updatePositionMargin(
+                    msg.sender,
+                    tickLower,
+                    tickUpper,
+                    marginDelta
                 );
             }
 
@@ -237,7 +264,7 @@ contract Periphery is IPeriphery {
 
     /// @notice Add liquidity to an initialized pool
     function mintOrBurn(MintOrBurnParams memory params)
-        external
+        public
         payable
         override
         returns (int256 positionMarginRequirement)
@@ -344,7 +371,7 @@ contract Periphery is IPeriphery {
     }
 
     function swap(SwapPeripheryParams memory params)
-        external
+        public
         payable
         override
         returns (
@@ -422,6 +449,60 @@ contract Periphery is IPeriphery {
             _marginRequirement
         ) = vamm.swap(swapParams);
         _tickAfter = vamm.vammVars().tick;
+    }
+
+    function rolloverWithMint(
+        IMarginEngine marginEngine,
+        address owner,
+        int24 tickLower,
+        int24 tickUpper,
+        MintOrBurnParams memory paramsNewPosition
+    ) public payable returns (int256 newPositionMarginRequirement) {
+        require(paramsNewPosition.isMint, "only mint");
+
+        settlePositionAndWithdrawMargin(
+            marginEngine,
+            owner,
+            tickLower,
+            tickUpper
+        );
+
+        newPositionMarginRequirement = mintOrBurn(paramsNewPosition);
+    }
+
+    function rolloverWithSwap(
+        IMarginEngine marginEngine,
+        address owner,
+        int24 tickLower,
+        int24 tickUpper,
+        SwapPeripheryParams memory params
+    )
+        public
+        payable
+        returns (
+            int256 _fixedTokenDelta,
+            int256 _variableTokenDelta,
+            uint256 _cumulativeFeeIncurred,
+            int256 _fixedTokenDeltaUnbalanced,
+            int256 _marginRequirement,
+            int24 _tickAfter
+        )
+    {
+        settlePositionAndWithdrawMargin(
+            marginEngine,
+            owner,
+            tickLower,
+            tickUpper
+        );
+
+        (
+            _fixedTokenDelta,
+            _variableTokenDelta,
+            _cumulativeFeeIncurred,
+            _fixedTokenDeltaUnbalanced,
+            _marginRequirement,
+            _tickAfter
+        ) = swap(params);
     }
 
     function getCurrentTick(IMarginEngine marginEngine)

--- a/test/end_to_end/general_setup/general.ts
+++ b/test/end_to_end/general_setup/general.ts
@@ -348,13 +348,16 @@ export class ScenarioRunner {
       (await MarginCalculatorFactory.deploy()) as MarginCalculatorTest;
   }
 
-  async deployIRSContracts() {
+  async deployIRSContracts(
+    termStartTimestamp: BigNumber,
+    termEndTimestamp: BigNumber
+    ) : Promise<[IMarginEngine, IVAMM, IFCM?]>{
     // deploy IRS instance
     const deployTrx = await this.factory.deployIrsInstance(
       this.token.address,
       this.rateOracle.address,
-      this.termStartTimestamp,
-      this.termEndTimestamp,
+      termStartTimestamp,
+      termEndTimestamp,
       this.params.tickSpacing,
       { gasLimit: 10000000 }
     );
@@ -376,24 +379,27 @@ export class ScenarioRunner {
     const fcmAddress = log.args.fcm;
 
     const marginEngineFactory = await ethers.getContractFactory("MarginEngine");
-    this.marginEngine = marginEngineFactory.attach(
+    const marginEngine = marginEngineFactory.attach(
       marginEngineAddress
     ) as IMarginEngine;
 
     const vammFactory = await ethers.getContractFactory("VAMM");
-    this.vamm = vammFactory.attach(vammAddress) as IVAMM;
 
+    const vamm = vammFactory.attach(vammAddress) as IVAMM;
+
+    let fcm;
     switch (this.params.rateOracle) {
       case 1: {
         const fcmFactory = await ethers.getContractFactory("AaveFCM");
-        this.fcm = fcmFactory.attach(fcmAddress) as IFCM;
+
+        fcm = fcmFactory.attach(fcmAddress) as IFCM;
 
         break;
       }
 
       case 2: {
         const fcmFactory = await ethers.getContractFactory("CompoundFCM");
-        this.fcm = fcmFactory.attach(fcmAddress) as IFCM;
+        fcm = fcmFactory.attach(fcmAddress) as IFCM;
 
         break;
       }
@@ -410,30 +416,36 @@ export class ScenarioRunner {
         throw new Error("Unrecognized rate oracle");
       }
     }
+
+    return [marginEngine, vamm, fcm];
+
   }
 
-  async configureIRS() {
+  async configureIRS(marginEngine: IMarginEngine, vamm: IVAMM)
+  :  Promise<[IMarginEngine, IVAMM]> {
     // set margin engine parameters
-    await this.marginEngine.setVAMM(this.vamm.address);
-    await this.marginEngine.setMarginCalculatorParameters(
+    await marginEngine.setVAMM(vamm.address);
+    await marginEngine.setMarginCalculatorParameters(
       this.params.marginCalculatorParams
     );
-    await this.marginEngine.setLookbackWindowInSeconds(
+    await marginEngine.setLookbackWindowInSeconds(
       this.params.lookBackWindowAPY
     );
 
     // set VAMM parameters
     try {
-      await this.vamm.setFeeProtocol(this.params.feeProtocol);
+      await vamm.setFeeProtocol(this.params.feeProtocol);
     } catch (_) {
       console.log("same protocol fee as before");
     }
 
     try {
-      await this.vamm.setFee(this.params.fee);
+      await vamm.setFee(this.params.fee);
     } catch (_) {
       console.log("same fee percentage as before");
     }
+
+    return [marginEngine, vamm];
   }
 
   async mintAndApprove(address: string, amount: BigNumber) {
@@ -549,15 +561,25 @@ export class ScenarioRunner {
     );
     console.log();
 
+    await this.initIRSPool();
+  }
+
+  async initIRSPool() {
     // deploy an IRS instance
-    await this.deployIRSContracts();
+    [this.marginEngine, this.vamm, this.fcm] = await this.deployIRSContracts(
+      this.termStartTimestamp,
+      this.termEndTimestamp
+    );
     console.log(`VAMM: ${this.vamm.address}`);
     console.log(`marginEngine: ${this.marginEngine.address}`);
     console.log(`FCM: ${this.fcm ? this.fcm.address : "Undefined"}`);
     console.log();
 
     // configure the IRS instance
-    await this.configureIRS();
+    [this.marginEngine, this.vamm] = await this.configureIRS(
+      this.marginEngine,
+      this.vamm
+    );
 
     // configure the E2E setup
     await this.configureE2E();

--- a/test/end_to_end/general_setup/rollover/rolloverEth.ts
+++ b/test/end_to_end/general_setup/rollover/rolloverEth.ts
@@ -1,0 +1,328 @@
+import { expect } from "chai";
+import { ethers, waffle } from "hardhat";
+import { BigNumber, Wallet } from "ethers";
+import { toBn } from "evm-bn";
+import { consts } from "../../../helpers/constants";
+import {
+  advanceTimeAndBlock,
+  getCurrentTimestamp,
+} from "../../../helpers/time";
+import {
+  ALPHA,
+  APY_LOWER_MULTIPLIER,
+  APY_UPPER_MULTIPLIER,
+  BETA,
+  encodeSqrtRatioX96,
+  MAX_SQRT_RATIO,
+  MIN_DELTA_IM,
+  MIN_DELTA_LM,
+  MIN_SQRT_RATIO,
+  TICK_SPACING,
+  T_MAX,
+  XI_LOWER,
+  XI_UPPER,
+} from "../../../shared/utilities";
+import { ScenarioRunner, e2eParameters } from "../general";
+import { IVAMM, IMarginEngine } from "../../../../typechain";
+
+const { provider } = waffle;
+
+const MAX_AMOUNT = BigNumber.from(10).pow(27);
+
+const e2eParamsStableCoin: e2eParameters = {
+  duration: consts.ONE_MONTH,
+  numActors: 5,
+  marginCalculatorParams: {
+    apyUpperMultiplierWad: APY_UPPER_MULTIPLIER,
+    apyLowerMultiplierWad: APY_LOWER_MULTIPLIER,
+    minDeltaLMWad: MIN_DELTA_LM,
+    minDeltaIMWad: MIN_DELTA_IM,
+    sigmaSquaredWad: toBn("0.15"),
+    alphaWad: ALPHA,
+    betaWad: BETA,
+    xiUpperWad: XI_UPPER,
+    xiLowerWad: XI_LOWER,
+    tMaxWad: T_MAX,
+
+    devMulLeftUnwindLMWad: toBn("0.5"),
+    devMulRightUnwindLMWad: toBn("0.5"),
+    devMulLeftUnwindIMWad: toBn("0.8"),
+    devMulRightUnwindIMWad: toBn("0.8"),
+
+    fixedRateDeviationMinLeftUnwindLMWad: toBn("0.1"),
+    fixedRateDeviationMinRightUnwindLMWad: toBn("0.1"),
+
+    fixedRateDeviationMinLeftUnwindIMWad: toBn("0.3"),
+    fixedRateDeviationMinRightUnwindIMWad: toBn("0.3"),
+
+    gammaWad: toBn("1.0"),
+    minMarginToIncentiviseLiquidators: 0, // keep zero for now then do tests with the min liquidator incentive
+  },
+  lookBackWindowAPY: consts.ONE_WEEK,
+  startingPrice: encodeSqrtRatioX96(1, 1),
+  feeProtocol: 0,
+  fee: toBn("0"),
+  tickSpacing: TICK_SPACING,
+  positions: [
+    [0, -TICK_SPACING, TICK_SPACING],
+    [1, -3 * TICK_SPACING, -TICK_SPACING],
+    [2, -TICK_SPACING, TICK_SPACING],
+    [3, -TICK_SPACING, TICK_SPACING],
+    [4, -TICK_SPACING, TICK_SPACING],
+  ],
+  isWETH: true,
+  rateOracle: 4,
+};
+
+class ScenarioRunnerEthPool extends ScenarioRunner {
+  wallets!: Wallet[];
+
+  override async run() {
+    await this.factory.setPeriphery(this.periphery.address);
+
+    await this.vamm.setIsAlpha(true);
+    await this.marginEngine.setIsAlpha(true);
+    await this.periphery.setLPMarginCap(this.vamm.address, toBn("4000"));
+
+    this.wallets = [];
+    for (let i = 0; i < this.params.numActors; i++) {
+      const wallet = await provider.getWallets()[i];
+      await this.token.mint(wallet.address, MAX_AMOUNT);
+      await this.token
+        .connect(wallet)
+        .approve(this.periphery.address, MAX_AMOUNT);
+      this.wallets.push(wallet);
+    }
+
+    // provide enough margin for pool to allow rollovers
+    {
+      const mintOrBurnParameters = {
+        marginEngine: this.marginEngine.address,
+        tickLower: this.positions[4][1],
+        tickUpper: this.positions[4][2],
+        notional: toBn("6000"),
+        isMint: true,
+        marginDelta: toBn("2100"),
+      };
+
+      // add 1,000,000 liquidity to Position 0
+      await this.periphery
+        .connect(this.wallets[4])
+        .mintOrBurn(mintOrBurnParameters);
+    }
+
+    // make LP position
+    {
+      const mintOrBurnParameters = {
+        marginEngine: this.marginEngine.address,
+        tickLower: this.positions[0][1],
+        tickUpper: this.positions[0][2],
+        notional: toBn("6000"),
+        isMint: true,
+        marginDelta: toBn("210"),
+      };
+      await this.periphery
+        .connect(this.wallets[0])
+        .mintOrBurn(mintOrBurnParameters);
+    }
+
+    // trader 2 buys 2,995 VT
+    {
+      const swapParameters = {
+        marginEngine: this.marginEngine.address,
+        isFT: false,
+        notional: toBn("2995"),
+        sqrtPriceLimitX96: BigNumber.from(MIN_SQRT_RATIO.add(1)),
+        tickLower: this.positions[2][1],
+        tickUpper: this.positions[2][2],
+        marginDelta: toBn("1000"),
+      };
+      await this.periphery.connect(this.wallets[2]).swap(swapParameters);
+    }
+
+    // trader 3 buys 100 FT
+    {
+      const swapParameters = {
+        marginEngine: this.marginEngine.address,
+        isFT: true,
+        notional: toBn("100"),
+        sqrtPriceLimitX96: BigNumber.from(MAX_SQRT_RATIO.sub(1)),
+        tickLower: this.positions[3][1],
+        tickUpper: this.positions[3][2],
+        marginDelta: toBn("10"),
+      };
+      await this.periphery.connect(this.wallets[3]).swap(swapParameters);
+    }
+  }
+}
+
+describe("Rollover Eth Pool", async () => {
+  let initSetup: ScenarioRunnerEthPool;
+  let secondMarginEngine: IMarginEngine;
+  let secondVAMM: IVAMM;
+  let secondStart: BigNumber;
+  let secondEnd: BigNumber;
+
+  before("setup the old and new pool", async () => {
+    initSetup = new ScenarioRunnerEthPool(e2eParamsStableCoin);
+    await initSetup.init();
+    await initSetup.run();
+
+    const now = await getCurrentTimestamp(provider);
+    const start = now + consts.ONE_MONTH.toNumber();
+    const end = start + consts.ONE_YEAR.toNumber();
+    secondStart = toBn(start.toString());
+    secondEnd = toBn(end.toString());
+    [secondMarginEngine, secondVAMM] = await initSetup.deployIRSContracts(
+      secondStart,
+      secondEnd
+    );
+    [secondMarginEngine, secondVAMM] = await initSetup.configureIRS(
+      secondMarginEngine,
+      secondVAMM
+    );
+
+    await secondVAMM.setIsAlpha(true);
+    await secondMarginEngine.setIsAlpha(true);
+    await initSetup.periphery.setLPMarginCap(secondVAMM.address, toBn("4000"));
+
+    await advanceTimeAndBlock(consts.ONE_MONTH.add(consts.ONE_HOUR), 1); // 1st pool reaches maturity
+  });
+
+  it("failed LP rolling", async () => {
+    const lpAddress = initSetup.wallets[0].address;
+
+    const mintOrBurnParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      tickLower: initSetup.positions[0][1],
+      tickUpper: initSetup.positions[0][2],
+      notional: toBn("6000"),
+      isMint: true,
+      marginDelta: toBn("4001"),
+    };
+
+    await expect(
+      initSetup.periphery.rolloverWithMint(
+        initSetup.marginEngine.address,
+        lpAddress,
+        initSetup.positions[0][1],
+        initSetup.positions[0][2],
+        mintOrBurnParametersStageTwo
+      )
+    ).to.be.reverted;
+  });
+
+  it("LP rolling with Weth", async () => {
+    const lpAddress = initSetup.wallets[0].address;
+
+    const lpBalaceInit = await initSetup.token.balanceOf(lpAddress);
+    const lpmarginCumulativeInit =
+      await initSetup.periphery.lpMarginCumulatives(initSetup.vamm.address);
+
+    const mintOrBurnParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      tickLower: initSetup.positions[0][1],
+      tickUpper: initSetup.positions[0][2],
+      notional: toBn("6000"),
+      isMint: true,
+      marginDelta: toBn("400"),
+    };
+
+    await initSetup.periphery.rolloverWithMint(
+      initSetup.marginEngine.address,
+      lpAddress,
+      initSetup.positions[0][1],
+      initSetup.positions[0][2],
+      mintOrBurnParametersStageTwo
+    );
+
+    expect(await initSetup.token.balanceOf(lpAddress)).to.be.closeTo(
+      lpBalaceInit.sub(toBn("190")),
+      toBn("10")
+    );
+
+    expect(
+      await initSetup.periphery.lpMarginCumulatives(initSetup.vamm.address)
+    ).to.be.equal(lpmarginCumulativeInit.sub(toBn("210")));
+
+    expect(
+      await initSetup.periphery.lpMarginCumulatives(secondVAMM.address)
+    ).to.be.equal(toBn("400"));
+
+    expect(
+      await initSetup.token.balanceOf(secondMarginEngine.address)
+    ).to.be.equal(toBn("400"));
+  });
+
+  it("VT rolling with ETH", async () => {
+    const vtAddress = initSetup.wallets[2].address;
+
+    const vtBalaceInit = await initSetup.token.balanceOf(vtAddress);
+
+    const swapParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      isFT: false,
+      notional: toBn("2995"),
+      sqrtPriceLimitX96: BigNumber.from(MIN_SQRT_RATIO.add(1)),
+      tickLower: initSetup.positions[2][1],
+      tickUpper: initSetup.positions[2][2],
+      marginDelta: toBn("0"),
+    };
+
+    await initSetup.periphery
+      .connect(initSetup.wallets[2])
+      .rolloverWithSwap(
+        initSetup.marginEngine.address,
+        vtAddress,
+        initSetup.positions[2][1],
+        initSetup.positions[2][2],
+        swapParametersStageTwo,
+        { value: ethers.utils.parseUnits("31", "ether") }
+      );
+
+    expect(await initSetup.token.balanceOf(vtAddress)).to.be.closeTo(
+      vtBalaceInit.add(toBn("1000")),
+      toBn("10")
+    );
+
+    expect(
+      await initSetup.token.balanceOf(secondMarginEngine.address)
+    ).to.be.equal(toBn("431"));
+  });
+
+  it("FT rolling with WETh and ETH", async () => {
+    const ftAddress = initSetup.wallets[3].address;
+
+    const ftBalaceInit = await initSetup.token.balanceOf(ftAddress);
+
+    const swapParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      isFT: true,
+      notional: toBn("100"),
+      sqrtPriceLimitX96: BigNumber.from(MAX_SQRT_RATIO.sub(1)),
+      tickLower: initSetup.positions[3][1],
+      tickUpper: initSetup.positions[3][2],
+      marginDelta: toBn("14"),
+    };
+
+    await initSetup.periphery
+      .connect(initSetup.wallets[3])
+      .rolloverWithSwap(
+        initSetup.marginEngine.address,
+        ftAddress,
+        initSetup.positions[3][1],
+        initSetup.positions[3][2],
+        swapParametersStageTwo,
+        { value: ethers.utils.parseUnits("1", "ether") }
+      );
+
+    expect(await initSetup.token.balanceOf(ftAddress)).to.be.closeTo(
+      ftBalaceInit.sub(toBn("4")),
+      toBn("10")
+    );
+
+    expect(
+      await initSetup.token.balanceOf(secondMarginEngine.address)
+    ).to.be.equal(toBn("446"));
+  });
+});

--- a/test/end_to_end/general_setup/rollover/rolloverStableCoin.ts
+++ b/test/end_to_end/general_setup/rollover/rolloverStableCoin.ts
@@ -1,0 +1,395 @@
+import { expect } from "chai";
+import { waffle } from "hardhat";
+import { BigNumber, Wallet } from "ethers";
+import { toBn } from "evm-bn";
+import { consts } from "../../../helpers/constants";
+import {
+  advanceTimeAndBlock,
+  getCurrentTimestamp,
+} from "../../../helpers/time";
+import {
+  ALPHA,
+  APY_LOWER_MULTIPLIER,
+  APY_UPPER_MULTIPLIER,
+  BETA,
+  encodeSqrtRatioX96,
+  MAX_SQRT_RATIO,
+  MIN_DELTA_IM,
+  MIN_DELTA_LM,
+  MIN_SQRT_RATIO,
+  TICK_SPACING,
+  T_MAX,
+  XI_LOWER,
+  XI_UPPER,
+} from "../../../shared/utilities";
+import { ScenarioRunner, e2eParameters } from "../general";
+import { IVAMM, IMarginEngine } from "../../../../typechain";
+
+const { provider } = waffle;
+
+const MAX_AMOUNT = BigNumber.from(10).pow(27);
+
+const e2eParamsStableCoin: e2eParameters = {
+  duration: consts.ONE_MONTH,
+  numActors: 5,
+  marginCalculatorParams: {
+    apyUpperMultiplierWad: APY_UPPER_MULTIPLIER,
+    apyLowerMultiplierWad: APY_LOWER_MULTIPLIER,
+    minDeltaLMWad: MIN_DELTA_LM,
+    minDeltaIMWad: MIN_DELTA_IM,
+    sigmaSquaredWad: toBn("0.15"),
+    alphaWad: ALPHA,
+    betaWad: BETA,
+    xiUpperWad: XI_UPPER,
+    xiLowerWad: XI_LOWER,
+    tMaxWad: T_MAX,
+
+    devMulLeftUnwindLMWad: toBn("0.5"),
+    devMulRightUnwindLMWad: toBn("0.5"),
+    devMulLeftUnwindIMWad: toBn("0.8"),
+    devMulRightUnwindIMWad: toBn("0.8"),
+
+    fixedRateDeviationMinLeftUnwindLMWad: toBn("0.1"),
+    fixedRateDeviationMinRightUnwindLMWad: toBn("0.1"),
+
+    fixedRateDeviationMinLeftUnwindIMWad: toBn("0.3"),
+    fixedRateDeviationMinRightUnwindIMWad: toBn("0.3"),
+
+    gammaWad: toBn("1.0"),
+    minMarginToIncentiviseLiquidators: 0, // keep zero for now then do tests with the min liquidator incentive
+  },
+  lookBackWindowAPY: consts.ONE_WEEK,
+  startingPrice: encodeSqrtRatioX96(1, 1),
+  feeProtocol: 0,
+  fee: toBn("0"),
+  tickSpacing: TICK_SPACING,
+  positions: [
+    [0, -TICK_SPACING, TICK_SPACING],
+    [1, -3 * TICK_SPACING, -TICK_SPACING],
+    [2, -TICK_SPACING, TICK_SPACING],
+    [3, -TICK_SPACING, TICK_SPACING],
+    [4, -TICK_SPACING, TICK_SPACING],
+  ],
+  isWETH: false,
+  rateOracle: 1,
+};
+
+class ScenarioRunnerStableCoin extends ScenarioRunner {
+  wallets!: Wallet[];
+
+  override async run() {
+    await this.factory.setPeriphery(this.periphery.address);
+
+    await this.vamm.setIsAlpha(true);
+    await this.marginEngine.setIsAlpha(true);
+    await this.periphery.setLPMarginCap(this.vamm.address, toBn("4000"));
+
+    this.wallets = [];
+    for (let i = 0; i < this.params.numActors; i++) {
+      const wallet = await provider.getWallets()[i];
+      await this.token.mint(wallet.address, MAX_AMOUNT);
+      await this.token
+        .connect(wallet)
+        .approve(this.periphery.address, MAX_AMOUNT);
+      this.wallets.push(wallet);
+    }
+
+    // provide enough margin for pool to allow rollovers
+    {
+      const mintOrBurnParameters = {
+        marginEngine: this.marginEngine.address,
+        tickLower: this.positions[4][1],
+        tickUpper: this.positions[4][2],
+        notional: toBn("6000"),
+        isMint: true,
+        marginDelta: toBn("2100"),
+      };
+
+      await this.periphery
+        .connect(this.wallets[4])
+        .mintOrBurn(mintOrBurnParameters);
+    }
+
+    // LP position
+    {
+      const mintOrBurnParameters = {
+        marginEngine: this.marginEngine.address,
+        tickLower: this.positions[0][1],
+        tickUpper: this.positions[0][2],
+        notional: toBn("6000"),
+        isMint: true,
+        marginDelta: toBn("210"),
+      };
+
+      await this.periphery
+        .connect(this.wallets[0])
+        .mintOrBurn(mintOrBurnParameters);
+    }
+
+    // trader 2 buys 2,995 VT
+    {
+      const swapParameters = {
+        marginEngine: this.marginEngine.address,
+        isFT: false,
+        notional: toBn("2995"),
+        sqrtPriceLimitX96: BigNumber.from(MIN_SQRT_RATIO.add(1)),
+        tickLower: this.positions[2][1],
+        tickUpper: this.positions[2][2],
+        marginDelta: toBn("1000"),
+      };
+
+      await this.periphery.connect(this.wallets[2]).swap(swapParameters);
+    }
+
+    // trader 3 buys 100 FT
+    {
+      const swapParameters = {
+        marginEngine: this.marginEngine.address,
+        isFT: true,
+        notional: toBn("100"),
+        sqrtPriceLimitX96: BigNumber.from(MAX_SQRT_RATIO.sub(1)),
+        tickLower: this.positions[3][1],
+        tickUpper: this.positions[3][2],
+        marginDelta: toBn("10"),
+      };
+
+      await this.periphery.connect(this.wallets[3]).swap(swapParameters);
+    }
+  }
+}
+
+describe("Rollover StableCoin", async () => {
+  let initSetup: ScenarioRunnerStableCoin;
+  let secondMarginEngine: IMarginEngine;
+  let secondVAMM: IVAMM;
+  let secondStart: BigNumber;
+  let secondEnd: BigNumber;
+
+  before("setup the old and new pool", async () => {
+    initSetup = new ScenarioRunnerStableCoin(e2eParamsStableCoin);
+    await initSetup.init();
+    await initSetup.run();
+
+    const now = await getCurrentTimestamp(provider);
+    const start = now + consts.ONE_MONTH.toNumber();
+    const end = start + consts.ONE_YEAR.toNumber();
+    secondStart = toBn(start.toString());
+    secondEnd = toBn(end.toString());
+    [secondMarginEngine, secondVAMM] = await initSetup.deployIRSContracts(
+      secondStart,
+      secondEnd
+    );
+    [secondMarginEngine, secondVAMM] = await initSetup.configureIRS(
+      secondMarginEngine,
+      secondVAMM
+    );
+
+    await secondVAMM.setIsAlpha(true);
+    await secondMarginEngine.setIsAlpha(true);
+    await initSetup.periphery.setLPMarginCap(secondVAMM.address, toBn("4000"));
+  });
+
+  it("failed rolling - not yet mature", async () => {
+    const ftAddress = initSetup.wallets[3].address;
+
+    const swapParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      isFT: true,
+      notional: toBn("100"),
+      sqrtPriceLimitX96: BigNumber.from(MAX_SQRT_RATIO.sub(1)),
+      tickLower: initSetup.positions[3][1],
+      tickUpper: initSetup.positions[3][2],
+      marginDelta: toBn("14"),
+    };
+
+    await expect(
+      initSetup.periphery
+        .connect(initSetup.wallets[3])
+        .rolloverWithSwap(
+          initSetup.marginEngine.address,
+          ftAddress,
+          initSetup.positions[3][1],
+          initSetup.positions[3][2],
+          swapParametersStageTwo
+        )
+    ).to.be.revertedWith("CannotSettleBeforeMaturity()");
+
+    await advanceTimeAndBlock(consts.ONE_MONTH.add(consts.ONE_HOUR), 1); // 1st pool reaches maturity
+  });
+
+  it("failed LP rolling - margin caps", async () => {
+    const lpAddress = initSetup.wallets[0].address;
+
+    const mintOrBurnParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      tickLower: initSetup.positions[0][1],
+      tickUpper: initSetup.positions[0][2],
+      notional: toBn("6000"),
+      isMint: true,
+      marginDelta: toBn("4001"),
+    };
+
+    await expect(
+      initSetup.periphery.rolloverWithMint(
+        initSetup.marginEngine.address,
+        lpAddress,
+        initSetup.positions[0][1],
+        initSetup.positions[0][2],
+        mintOrBurnParametersStageTwo
+      )
+    ).to.be.reverted;
+  });
+
+  it("LP rolling", async () => {
+    const lpAddress = initSetup.wallets[0].address;
+
+    const lpBalaceInit = await initSetup.token.balanceOf(lpAddress);
+    const lpmarginCumulativeInit =
+      await initSetup.periphery.lpMarginCumulatives(initSetup.vamm.address);
+
+    const mintOrBurnParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      tickLower: initSetup.positions[0][1],
+      tickUpper: initSetup.positions[0][2],
+      notional: toBn("6000"),
+      isMint: true,
+      marginDelta: toBn("400"),
+    };
+
+    await initSetup.periphery.rolloverWithMint(
+      initSetup.marginEngine.address,
+      lpAddress,
+      initSetup.positions[0][1],
+      initSetup.positions[0][2],
+      mintOrBurnParametersStageTwo
+    );
+
+    expect(await initSetup.token.balanceOf(lpAddress)).to.be.closeTo(
+      lpBalaceInit.sub(toBn("190")),
+      toBn("10")
+    );
+
+    expect(
+      await initSetup.periphery.lpMarginCumulatives(initSetup.vamm.address)
+    ).to.be.equal(lpmarginCumulativeInit.sub(toBn("210")));
+
+    expect(
+      await initSetup.periphery.lpMarginCumulatives(secondVAMM.address)
+    ).to.be.equal(toBn("400"));
+
+    expect(
+      await initSetup.token.balanceOf(secondMarginEngine.address)
+    ).to.be.equal(toBn("400"));
+  });
+
+  it("VT rolling", async () => {
+    const vtAddress = initSetup.wallets[2].address;
+
+    const vtBalaceInit = await initSetup.token.balanceOf(vtAddress);
+
+    const swapParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      isFT: false,
+      notional: toBn("2995"),
+      sqrtPriceLimitX96: BigNumber.from(MIN_SQRT_RATIO.add(1)),
+      tickLower: initSetup.positions[2][1],
+      tickUpper: initSetup.positions[2][2],
+      marginDelta: toBn("1000"),
+    };
+
+    await initSetup.periphery
+      .connect(initSetup.wallets[2])
+      .rolloverWithSwap(
+        initSetup.marginEngine.address,
+        vtAddress,
+        initSetup.positions[2][1],
+        initSetup.positions[2][2],
+        swapParametersStageTwo
+      );
+
+    expect(await initSetup.token.balanceOf(vtAddress)).to.be.closeTo(
+      vtBalaceInit,
+      toBn("10")
+    );
+
+    expect(
+      await initSetup.token.balanceOf(secondMarginEngine.address)
+    ).to.be.equal(toBn("1400"));
+  });
+
+  it("FT rolling", async () => {
+    const ftAddress = initSetup.wallets[3].address;
+
+    const ftBalaceInit = await initSetup.token.balanceOf(ftAddress);
+
+    const swapParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      isFT: true,
+      notional: toBn("100"),
+      sqrtPriceLimitX96: BigNumber.from(MAX_SQRT_RATIO.sub(1)),
+      tickLower: initSetup.positions[3][1],
+      tickUpper: initSetup.positions[3][2],
+      marginDelta: toBn("14"),
+    };
+
+    await initSetup.periphery
+      .connect(initSetup.wallets[3])
+      .rolloverWithSwap(
+        initSetup.marginEngine.address,
+        ftAddress,
+        initSetup.positions[3][1],
+        initSetup.positions[3][2],
+        swapParametersStageTwo
+      );
+
+    expect(await initSetup.token.balanceOf(ftAddress)).to.be.closeTo(
+      ftBalaceInit.sub(toBn("4")),
+      toBn("10")
+    );
+
+    expect(
+      await initSetup.token.balanceOf(secondMarginEngine.address)
+    ).to.be.equal(toBn("1414"));
+  });
+
+  it("continue as usual after rollover", async () => {
+    const mintOrBurnParametersStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      tickLower: initSetup.positions[0][1],
+      tickUpper: initSetup.positions[0][2],
+      notional: toBn("6000"),
+      isMint: true,
+      marginDelta: toBn("400"),
+    };
+
+    await initSetup.periphery.mintOrBurn(mintOrBurnParametersStageTwo);
+
+    const swapParametersVtStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      isFT: false,
+      notional: toBn("2995"),
+      sqrtPriceLimitX96: BigNumber.from(MIN_SQRT_RATIO.add(1)),
+      tickLower: initSetup.positions[2][1],
+      tickUpper: initSetup.positions[2][2],
+      marginDelta: toBn("1000"),
+    };
+
+    await initSetup.periphery
+      .connect(initSetup.wallets[2])
+      .swap(swapParametersVtStageTwo);
+
+    const swapParametersFtStageTwo = {
+      marginEngine: secondMarginEngine.address,
+      isFT: true,
+      notional: toBn("100"),
+      sqrtPriceLimitX96: BigNumber.from(MAX_SQRT_RATIO.sub(1)),
+      tickLower: initSetup.positions[3][1],
+      tickUpper: initSetup.positions[3][2],
+      marginDelta: toBn("14"),
+    };
+
+    await initSetup.periphery
+      .connect(initSetup.wallets[3])
+      .swap(swapParametersFtStageTwo);
+  });
+});


### PR DESCRIPTION
Added rollover functions in the Periphery
- rollover with mint: settle and withdraw margin and then mint into new pool
- rollover with swap: settle and withdraw margin and then mint into new pool
*allow margin deposit in both ETH and WETH
*modify general testing setup to allow multiple IRS pool deployment