### PR TITLE
getHistoricalData fixes, enhancements

### DIFF
--- a/contracts/rate_oracles/BaseRateOracle.sol
+++ b/contracts/rate_oracles/BaseRateOracle.sol
@@ -10,11 +10,10 @@ import "../interfaces/IFactory.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../core_libraries/Time.sol";
 import "../utils/WadRayMath.sol";
-import "hardhat/console.sol";
 
 /// @notice Common contract base for a Rate Oracle implementation.
 ///  This contract is abstract. To make the contract deployable override the
-/// `getCurrentRateInRay` and `getLastUpdatedRate` functions and the `UNDERLYING_YIELD_BEARING_PROTOCOL_ID` constant.
+/// `getLastUpdatedRate` function and the `UNDERLYING_YIELD_BEARING_PROTOCOL_ID` constant.
 /// @dev Each specific rate oracle implementation will need to implement the virtual functions
 abstract contract BaseRateOracle is IRateOracle, Ownable {
     uint256 public constant ONE_IN_WAD = 1e18;
@@ -101,7 +100,7 @@ abstract contract BaseRateOracle is IRateOracle, Ownable {
             uint32 lastUpdatedTimestamp,
             uint256 lastUpdatedRate
         ) = getLastUpdatedRate();
-
+        
         // `observations.initialize` will check that all times are correctly sorted so no need to check here
         times[length] = lastUpdatedTimestamp;
         results[length] = lastUpdatedRate;

--- a/contracts/rate_oracles/RocketPoolRateOracle.sol
+++ b/contracts/rate_oracles/RocketPoolRateOracle.sol
@@ -7,7 +7,6 @@ import "../interfaces/rocketPool/IRocketEth.sol";
 import "../interfaces/rocketPool/IRocketNetworkBalances.sol";
 import "../rate_oracles/BaseRateOracle.sol";
 import "../utils/WadRayMath.sol";
-import "hardhat/console.sol";
 
 contract RocketPoolRateOracle is BaseRateOracle, IRocketPoolRateOracle {
     IRocketEth public override rocketEth;
@@ -49,17 +48,8 @@ contract RocketPoolRateOracle is BaseRateOracle, IRocketPoolRateOracle {
 
         // RocketPool can only give us a block number of the most recent update
         // We estimate a timestamp using recent blocks-per-second data
-        uint256 lastUpdatedBlockNumber = rocketNetworkBalances
-            .getBalancesBlock();
+        uint256 lastUpdatedBlockNumber = rocketNetworkBalances.getBalancesBlock();
         (uint256 blockChange, uint32 timeChange) = getBlockSlope();
-
-        // console.log("block.number in getting last updated rate", block.number);
-        // console.log(
-        //     "block.timestamp in getting last updated rate",
-        //     block.timestamp
-        // );
-        // console.log("blockChange", blockChange);
-        // console.log("timeChange", timeChange);
 
         uint256 lastUpdatedTimestamp = block.timestamp -
             ((block.number - lastUpdatedBlockNumber) * timeChange) /

--- a/test/main_contracts/marginEngine.ts
+++ b/test/main_contracts/marginEngine.ts
@@ -1,7 +1,7 @@
 import { ethers, waffle } from "hardhat";
 import { BigNumber, utils, Wallet } from "ethers";
 import { expect } from "../shared/expect";
-import { metaFixture, tickMathFixture } from "../shared/fixtures";
+import { metaFixture } from "../shared/fixtures";
 import { toBn } from "evm-bn";
 import {
   ERC20Mock,
@@ -51,18 +51,18 @@ describe("MarginEngine", () => {
     [wallet, other] = await (ethers as any).getSigners();
     loadFixture = createFixtureLoader([wallet, other]);
 
-    const { testTickMath } = await loadFixture(tickMathFixture);
+    // const { testTickMath } = await loadFixture(tickMathFixture);
 
-    const min_tick = -69100;
-    const max_tick = 69100;
+    // const min_tick = -69100;
+    // const max_tick = 69100;
 
-    const min_price = await testTickMath.getSqrtRatioAtTick(-69100);
-    const max_price = await testTickMath.getSqrtRatioAtTick(69100);
+    // const min_price = await testTickMath.getSqrtRatioAtTick(-69100);
+    // const max_price = await testTickMath.getSqrtRatioAtTick(69100);
 
-    console.log(" min_tick :", min_tick.toString());
-    console.log("min_price :", min_price.toString());
-    console.log(" max_tick :", max_tick.toString());
-    console.log("max_price :", max_price.toString());
+    // console.log(" min_tick :", min_tick.toString());
+    // console.log("min_price :", min_price.toString());
+    // console.log(" max_tick :", max_tick.toString());
+    // console.log("max_price :", max_price.toString());
   });
 
   beforeEach("deploy fixture", async () => {


### PR DESCRIPTION
Check that only one platform is specified. Check that borrow only specified when compatible. Remove erroneous message re: compound + borrow. Calculate instantaneous APY for compound borrow.

Also remove a few console logs and update base rate oracle's inline documentation