### PR TITLE
Use data generators to get trusted data points during rate oracle deploy

### DIFF
--- a/deploy/3.rateOracles.ts
+++ b/deploy/3.rateOracles.ts
@@ -4,22 +4,26 @@ import { ethers } from "hardhat";
 import { getConfig } from "../deployConfig/config";
 import {
   applyBufferConfig,
-  convertTrustedRateOracleDataPoints,
   RateOracleConfigForTemplate,
 } from "../deployConfig/utils";
-import { BaseRateOracle, ERC20 } from "../typechain";
+import {
+  BaseRateOracle,
+  ERC20,
+  IAaveV2LendingPool,
+  ILidoOracle,
+  IRocketEth,
+  IRocketNetworkBalances,
+  IStETH,
+} from "../typechain";
 import { BigNumber } from "ethers";
 import path from "path";
 import mustache from "mustache";
+import { Datum } from "../historicalData/generators/common";
+import { buildAaveDataGenerator } from "../historicalData/generators/aave";
+import { buildCompoundDataGenerator } from "../historicalData/generators/compound";
 
-interface RateOracleInstanceInfo {
-  contractName: string;
-  args: any[];
-  suffix: string | null;
-  rateOracleBufferSize: number;
-  minSecondsSinceLastUpdate: number;
-  maxIrsDurationInSeconds: number;
-}
+import { buildLidoDataGenerator } from "../historicalData/generators/lido";
+import { buildRocketDataGenerator } from "../historicalData/generators/rocket";
 
 interface RateOracleConfigTemplateData {
   rateOracles: RateOracleConfigForTemplate[];
@@ -36,7 +40,10 @@ async function writeRateOracleConfigToGnosisSafeTemplate(
   );
   const output = mustache.render(template, data);
 
-  fs.mkdirSync(path.join(__dirname, "..", "tasks", "JSONs"));
+  const jsonDir = path.join(__dirname, "..", "tasks", "JSONs");
+  if (!fs.existsSync(jsonDir)) {
+    fs.mkdirSync(jsonDir);
+  }
   fs.writeFileSync(
     path.join(__dirname, "..", "tasks", "JSONs", "rateOracleConfig.json"),
     output
@@ -45,38 +52,74 @@ async function writeRateOracleConfigToGnosisSafeTemplate(
 
 let multisigConfig: RateOracleConfigForTemplate[] = [];
 
-const deployAndConfigureRateOracleInstance = async (
-  hre: HardhatRuntimeEnvironment,
-  instance: RateOracleInstanceInfo
-) => {
+interface RateOracleConfig {
+  name: string | null;
+  rateOracleBufferSize: number;
+  minSecondsSinceLastUpdate: number;
+}
+interface DeployAndConfigureWithGeneratorArgs {
+  hre: HardhatRuntimeEnvironment;
+  initialArgs: any[];
+  rateOracleConfig: RateOracleConfig;
+  contractName: string;
+  trustedDataPointsGenerator: AsyncGenerator<Datum> | null;
+}
+
+const deployAndConfigureWithGenerator = async ({
+  hre,
+  initialArgs,
+  rateOracleConfig,
+  contractName,
+  trustedDataPointsGenerator: generator,
+}: DeployAndConfigureWithGeneratorArgs) => {
   const { deploy } = hre.deployments;
   const { deployer, multisig } = await hre.getNamedAccounts();
   const doLogging = true;
 
+  // Get the maxIrsDuration (used to sanity check buffer size)
+  const network = hre.network.name;
+  const deployConfig = getConfig(network);
+  const maxIrsDurationInSeconds = deployConfig.maxIrsDurationInSeconds;
+
   const rateOracleIdentifier =
-    instance.contractName + (instance.suffix ? "_" + instance.suffix : "");
+    contractName + (rateOracleConfig.name ? "_" + rateOracleConfig.name : "");
   let rateOracleContract = (await ethers.getContractOrNull(
     rateOracleIdentifier
   )) as BaseRateOracle;
 
   if (!rateOracleContract) {
-    // There is no rate oracle already deployed with this rateOracleIdentifier. Deploy one now.
-    // console.log("rateOracleIdentifier", rateOracleIdentifier);
-    // console.log("instance.contractName:", instance.contractName);
-    // console.log("deployer:", deployer);
-    // console.log("args:", instance.args);
+    // There is no rate oracle already deployed with this rateOracleIdentifier. Deploy one now. But first, get some trusted data points if required.
+    let timestamps: number[] = [];
+    let rates: BigNumber[] = [];
+
+    if (generator) {
+      for await (const data of generator) {
+        timestamps.push(data.timestamp);
+        rates.push(data.rate);
+      }
+
+      // console.log(
+      //   `Got historical data (from generator): ${JSON.stringify(
+      //     timestamps
+      //   )}, ${JSON.stringify((rates as BigNumber[]).map((r) => r.toString()))}`
+      // );
+
+      // We skip the most recent timestamp & rate, since it should be from ~now and the contract will write this itself
+      timestamps = timestamps.slice(0, -1);
+      rates = rates.slice(0, -1);
+    }
+
+    const args = [...initialArgs, timestamps, rates];
+    console.log(`Deployment args are ${args.map((a) => a.toString())}`);
+
     await deploy(rateOracleIdentifier, {
-      contract: instance.contractName,
+      contract: contractName,
       from: deployer,
-      args: instance.args,
+      args: args,
       log: doLogging,
       gasLimit: 20000000,
     });
-    console.log(
-      `Deployed ${rateOracleIdentifier} (args: ${JSON.stringify(
-        instance.args
-      )})`
-    );
+    console.log(`Deployed ${rateOracleIdentifier}})`);
 
     rateOracleContract = (await ethers.getContract(
       rateOracleIdentifier
@@ -89,17 +132,17 @@ const deployAndConfigureRateOracleInstance = async (
     // Ensure the buffer is big enough. We must do this before writing any more rates or they may get overridden
     await applyBufferConfig(
       rateOracleContract,
-      BigNumber.from(instance.rateOracleBufferSize).toNumber(),
-      instance.minSecondsSinceLastUpdate,
-      instance.maxIrsDurationInSeconds
+      BigNumber.from(rateOracleConfig.rateOracleBufferSize).toNumber(),
+      rateOracleConfig.minSecondsSinceLastUpdate,
+      maxIrsDurationInSeconds
     );
   } else {
     // We do not have permissions to update rate oracle config, so we do a dry run to report out-of-date state
     const multisigChanges = await applyBufferConfig(
       rateOracleContract,
-      BigNumber.from(instance.rateOracleBufferSize).toNumber(),
-      instance.minSecondsSinceLastUpdate,
-      instance.maxIrsDurationInSeconds,
+      BigNumber.from(rateOracleConfig.rateOracleBufferSize).toNumber(),
+      rateOracleConfig.minSecondsSinceLastUpdate,
+      maxIrsDurationInSeconds,
       true
     );
     multisigConfig = multisigConfig.concat(multisigChanges);
@@ -131,90 +174,37 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const existingAaveLendingPoolAddress = aaveConfig?.aaveLendingPool;
     const aaveTokens = aaveConfig?.aaveTokens;
 
-    // console.log("aaveTokens", aaveTokens);
-    // console.log("existingAaveLendingPoolAddress", existingAaveLendingPoolAddress);
     if (existingAaveLendingPoolAddress && aaveTokens) {
-      const aaveLendingPool = await ethers.getContractAt(
+      const aaveLendingPool = (await ethers.getContractAt(
         "IAaveV2LendingPool",
         existingAaveLendingPoolAddress
-      );
+      )) as IAaveV2LendingPool;
 
       for (const tokenDefinition of aaveTokens) {
-        const { trustedTimestamps, trustedObservationValuesInRay } =
-          convertTrustedRateOracleDataPoints(
-            tokenDefinition.trustedDataPoints || []
+        let trustedDataPointsGenerator: AsyncGenerator<Datum> | null = null;
+
+        if (tokenDefinition.daysOfTrustedDataPoints) {
+          trustedDataPointsGenerator = await buildAaveDataGenerator(
+            hre,
+            tokenDefinition.address,
+            tokenDefinition.daysOfTrustedDataPoints,
+            tokenDefinition.borrow,
+            { lendingPool: aaveLendingPool }
           );
+        }
 
-        // const { timestamps, rates } = await hre.run("getHistoricalData", {
-        //   lookbackDays: 5,
-        //   aave: true,
-        //   token: tokenDefinition.name,
-        // });
-        // console.log(
-        //   `Got historical data: ${JSON.stringify(timestamps)}, ${JSON.stringify(
-        //     (rates as BigNumber[]).map((r) => r.toString())
-        //   )}`
-        // );
-
-        // For Aave, the first two constructor args are lending pool address and underlying token address
-        // For Aave, the address in the tokenDefinition is the address of the underlying token
-        const args = [
-          aaveLendingPool.address,
-          tokenDefinition.address,
-          trustedTimestamps,
-          trustedObservationValuesInRay,
-        ];
-
-        await deployAndConfigureRateOracleInstance(hre, {
-          args,
-          suffix: tokenDefinition.name,
-          contractName: "AaveRateOracle",
-          rateOracleBufferSize: tokenDefinition.rateOracleBufferSize,
-          minSecondsSinceLastUpdate: tokenDefinition.minSecondsSinceLastUpdate,
-          maxIrsDurationInSeconds: deployConfig.maxIrsDurationInSeconds,
+        await deployAndConfigureWithGenerator({
+          hre,
+          initialArgs: [aaveLendingPool.address, tokenDefinition.address],
+          rateOracleConfig: tokenDefinition,
+          contractName: tokenDefinition.borrow
+            ? "AaveBorrowRateOracle"
+            : "AaveRateOracle",
+          trustedDataPointsGenerator,
         });
       }
     }
     // End of Aave Rate Oracles
-  }
-
-  {
-    // Aave BORROW Rate Oracle
-    const aaveBorrowConfig = deployConfig.aaveBorrowConfig;
-    const existingAaveLendingPoolAddress = aaveBorrowConfig?.aaveLendingPool;
-    const aaveTokens = aaveBorrowConfig?.aaveTokens;
-    if (existingAaveLendingPoolAddress && aaveTokens) {
-      const aaveLendingPool = await ethers.getContractAt(
-        "IAaveV2LendingPool",
-        existingAaveLendingPoolAddress
-      );
-
-      for (const tokenDefinition of aaveTokens) {
-        const { trustedTimestamps, trustedObservationValuesInRay } =
-          convertTrustedRateOracleDataPoints(
-            tokenDefinition.trustedDataPoints || []
-          );
-
-        // For Aave, the first two constructor args are lending pool address and underlying token address
-        // For Aave, the address in the tokenDefinition is the address of the underlying token
-        const args = [
-          aaveLendingPool.address,
-          tokenDefinition.address,
-          trustedTimestamps,
-          trustedObservationValuesInRay,
-        ];
-
-        await deployAndConfigureRateOracleInstance(hre, {
-          args,
-          suffix: tokenDefinition.name,
-          contractName: "AaveBorrowRateOracle",
-          rateOracleBufferSize: tokenDefinition.rateOracleBufferSize,
-          minSecondsSinceLastUpdate: tokenDefinition.minSecondsSinceLastUpdate,
-          maxIrsDurationInSeconds: deployConfig.maxIrsDurationInSeconds,
-        });
-      }
-    }
-    // End of Aave Borrow Rate Oracles
   }
 
   // Compound Rate Oracles
@@ -229,8 +219,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         tokenDefinition.address
       );
 
-      // console.log("cToken", cToken.address);
-
       let underlyingAddress: string;
       let underlyingDecimals: number;
       let ethPool: boolean;
@@ -254,99 +242,35 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         ethPool = false;
       }
 
-      const { trustedTimestamps, trustedObservationValuesInRay } =
-        convertTrustedRateOracleDataPoints(
-          tokenDefinition.trustedDataPoints || []
+      let trustedDataPointsGenerator: AsyncGenerator<Datum> | null = null;
+
+      if (tokenDefinition.daysOfTrustedDataPoints) {
+        trustedDataPointsGenerator = await buildCompoundDataGenerator(
+          hre,
+          cToken.address,
+          tokenDefinition.daysOfTrustedDataPoints,
+          tokenDefinition.borrow,
+          ethPool
         );
+      }
 
-      // For Compound, the first three constructor args are the cToken address, underylying address and decimals of the underlying
-      // For Compound, the address in the tokenDefinition is the address of the underlying cToken
-      const args = [
-        cToken.address,
-        ethPool,
-        underlyingAddress,
-        underlyingDecimals,
-        trustedTimestamps,
-        trustedObservationValuesInRay,
-      ];
-
-      await deployAndConfigureRateOracleInstance(hre, {
-        args,
-        suffix: tokenDefinition.name,
-        contractName: "CompoundRateOracle",
-        rateOracleBufferSize: tokenDefinition.rateOracleBufferSize,
-        minSecondsSinceLastUpdate: tokenDefinition.minSecondsSinceLastUpdate,
-        maxIrsDurationInSeconds: deployConfig.maxIrsDurationInSeconds,
+      await deployAndConfigureWithGenerator({
+        hre,
+        initialArgs: [
+          cToken.address,
+          ethPool,
+          underlyingAddress,
+          underlyingDecimals,
+        ],
+        rateOracleConfig: tokenDefinition,
+        contractName: tokenDefinition.borrow
+          ? "CompoundBorrowRateOracle"
+          : "CompoundRateOracle",
+        trustedDataPointsGenerator,
       });
     }
   }
   // End of Compound Rate Oracles
-
-  // Compound Borrow Rate Oracles
-  // Configure these if we have a one or more cTokens configured
-  const compoundBorrowConfig = deployConfig.compoundBorrowConfig;
-  const compoundBorrowTokens =
-    compoundBorrowConfig && compoundBorrowConfig.compoundTokens;
-
-  if (compoundBorrowTokens) {
-    for (const tokenDefinition of compoundBorrowTokens) {
-      const cToken = await ethers.getContractAt(
-        "ICToken",
-        tokenDefinition.address
-      );
-
-      // console.log("cToken", cToken.address);
-
-      let underlyingAddress: string;
-      let underlyingDecimals: number;
-      let ethPool: boolean;
-
-      if (tokenDefinition.name === "cETH") {
-        if (deployConfig.weth) {
-          underlyingAddress = deployConfig.weth;
-          underlyingDecimals = 18;
-          ethPool = true;
-        } else {
-          throw new Error("WETH not found");
-        }
-      } else {
-        const underlying = (await ethers.getContractAt(
-          "@openzeppelin/contracts/token/ERC20/ERC20.sol:ERC20",
-          await cToken.underlying()
-        )) as ERC20;
-
-        underlyingAddress = underlying.address;
-        underlyingDecimals = await underlying.decimals();
-        ethPool = false;
-      }
-
-      const { trustedTimestamps, trustedObservationValuesInRay } =
-        convertTrustedRateOracleDataPoints(
-          tokenDefinition.trustedDataPoints || []
-        );
-
-      // For Compound, the first three constructor args are the cToken address, underylying address and decimals of the underlying
-      // For Compound, the address in the tokenDefinition is the address of the underlying cToken
-      const args = [
-        cToken.address,
-        ethPool,
-        underlyingAddress,
-        underlyingDecimals,
-        trustedTimestamps,
-        trustedObservationValuesInRay,
-      ];
-
-      await deployAndConfigureRateOracleInstance(hre, {
-        args,
-        suffix: tokenDefinition.name,
-        contractName: "CompoundBorrowRateOracle",
-        rateOracleBufferSize: tokenDefinition.rateOracleBufferSize,
-        minSecondsSinceLastUpdate: tokenDefinition.minSecondsSinceLastUpdate,
-        maxIrsDurationInSeconds: deployConfig.maxIrsDurationInSeconds,
-      });
-    }
-  }
-  // End of Compound Borrow Rate Oracles
 
   // Lido Rate Oracle
   const lidoConfig = deployConfig.lidoConfig;
@@ -354,9 +278,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const lidoOracleAddress = lidoConfig?.lidoOracle;
 
   if (lidoStETHAddress) {
-    const { trustedTimestamps, trustedObservationValuesInRay } =
-      convertTrustedRateOracleDataPoints(lidoConfig.defaults.trustedDataPoints);
-
     let wethAddress: string;
     if (deployConfig.weth) {
       wethAddress = deployConfig.weth;
@@ -364,22 +285,38 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       throw new Error("WETH not found");
     }
 
-    // For Lido, the first constructor arg is the stEth address
-    const args = [
-      lidoStETHAddress,
-      lidoOracleAddress,
-      wethAddress,
-      trustedTimestamps,
-      trustedObservationValuesInRay,
-    ];
+    let trustedDataPointsGenerator: AsyncGenerator<Datum> | null = null;
 
-    await deployAndConfigureRateOracleInstance(hre, {
-      args,
-      suffix: null,
+    if (lidoConfig.defaults.daysOfTrustedDataPoints) {
+      trustedDataPointsGenerator = await buildLidoDataGenerator(
+        hre,
+        lidoConfig.defaults.daysOfTrustedDataPoints,
+        {
+          stEth: (await ethers.getContractAt(
+            "IStETH",
+            lidoStETHAddress
+          )) as IStETH,
+          lidoOracle: lidoOracleAddress
+            ? ((await ethers.getContractAt(
+                "ILidoOracle",
+                lidoOracleAddress
+              )) as ILidoOracle)
+            : undefined,
+        }
+      );
+    }
+
+    await deployAndConfigureWithGenerator({
+      hre,
+      initialArgs: [lidoStETHAddress, lidoOracleAddress, wethAddress],
+      rateOracleConfig: {
+        name: null,
+        rateOracleBufferSize: lidoConfig.defaults.rateOracleBufferSize,
+        minSecondsSinceLastUpdate:
+          lidoConfig.defaults.minSecondsSinceLastUpdate,
+      },
       contractName: "LidoRateOracle",
-      rateOracleBufferSize: lidoConfig.defaults.rateOracleBufferSize,
-      minSecondsSinceLastUpdate: lidoConfig.defaults.minSecondsSinceLastUpdate,
-      maxIrsDurationInSeconds: deployConfig.maxIrsDurationInSeconds,
+      trustedDataPointsGenerator,
     });
   }
   // End of Lido Rate Oracle
@@ -390,35 +327,42 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const rocketNetworkBalancesAddress = rocketPoolConfig?.rocketNetworkBalances;
 
   if (rocketEthAddress && rocketNetworkBalancesAddress) {
-    const { trustedTimestamps, trustedObservationValuesInRay } =
-      convertTrustedRateOracleDataPoints(
-        rocketPoolConfig.defaults.trustedDataPoints
-      );
+    let trustedDataPointsGenerator: AsyncGenerator<Datum> | null = null;
+    const rocketEth = (await ethers.getContractAt(
+      "IRocketEth",
+      rocketEthAddress
+    )) as IRocketEth;
+    const rocketNetworkBalances = (await ethers.getContractAt(
+      "IRocketNetworkBalances",
+      rocketNetworkBalancesAddress
+    )) as IRocketNetworkBalances;
 
-    let wethAddress: string;
-    if (deployConfig.weth) {
-      wethAddress = deployConfig.weth;
-    } else {
-      throw new Error("WETH not found");
+    if (rocketPoolConfig.defaults.daysOfTrustedDataPoints) {
+      trustedDataPointsGenerator = await buildRocketDataGenerator(
+        hre,
+        rocketPoolConfig.defaults.daysOfTrustedDataPoints,
+        {
+          rocketEth,
+          rocketNetworkBalances,
+        }
+      );
     }
 
-    // For RocketPool, the first constructor arg is the rocketEth (RETH) address
-    const args = [
-      rocketEthAddress,
-      rocketNetworkBalancesAddress,
-      wethAddress,
-      trustedTimestamps,
-      trustedObservationValuesInRay,
-    ];
-
-    await deployAndConfigureRateOracleInstance(hre, {
-      args,
-      suffix: null,
+    await deployAndConfigureWithGenerator({
+      hre,
+      initialArgs: [
+        rocketEth.address,
+        rocketNetworkBalances.address,
+        deployConfig.weth,
+      ],
+      rateOracleConfig: {
+        name: null,
+        rateOracleBufferSize: rocketPoolConfig.defaults.rateOracleBufferSize,
+        minSecondsSinceLastUpdate:
+          rocketPoolConfig.defaults.minSecondsSinceLastUpdate,
+      },
       contractName: "RocketPoolRateOracle",
-      rateOracleBufferSize: rocketPoolConfig.defaults.rateOracleBufferSize,
-      minSecondsSinceLastUpdate:
-        rocketPoolConfig.defaults.minSecondsSinceLastUpdate,
-      maxIrsDurationInSeconds: deployConfig.maxIrsDurationInSeconds,
+      trustedDataPointsGenerator,
     });
   }
   // End of Rocket Pool Rate Oracle

--- a/deployConfig/config.ts
+++ b/deployConfig/config.ts
@@ -35,9 +35,19 @@ export const getConfig = (_networkName: string): ContractsConfig => {
   }
 
   const _config = config[_networkName];
+  const compoundTokens = _config.compoundConfig?.compoundTokens;
+  const aaveTokens = _config.compoundConfig?.compoundTokens;
+
   if (
-    _config.compoundConfig?.compoundTokens &&
-    duplicateExists(_config.compoundConfig?.compoundTokens?.map((t) => t.name))
+    compoundTokens &&
+    // check for borrow token duplicates
+    (duplicateExists(
+      compoundTokens?.filter((t) => t.borrow).map((t) => t.name)
+    ) ||
+      // check for non-borrow token duplicates
+      duplicateExists(
+        compoundTokens?.filter((t) => !t.borrow).map((t) => t.name)
+      ))
   ) {
     throw Error(
       `Duplicate token names configured for Compound on network ${_networkName}`
@@ -45,8 +55,11 @@ export const getConfig = (_networkName: string): ContractsConfig => {
   }
 
   if (
-    _config.aaveConfig?.aaveTokens &&
-    duplicateExists(_config.aaveConfig?.aaveTokens?.map((t) => t.name))
+    aaveTokens &&
+    // check for borrow token duplicates
+    (duplicateExists(aaveTokens?.filter((t) => t.borrow).map((t) => t.name)) ||
+      // check for non-borrow token duplicates
+      duplicateExists(aaveTokens?.filter((t) => !t.borrow).map((t) => t.name)))
   ) {
     throw Error(
       `Duplicate token names configured for Aave on network ${_networkName}`

--- a/deployConfig/goerli.ts
+++ b/deployConfig/goerli.ts
@@ -1,57 +1,4 @@
-import type { ContractsConfig, RateOracleDataPoint } from "./types";
-
-const goerliStEthDataPoints: RateOracleDataPoint[] = [
-  [1654485600, "1008924600350995571702479730"],
-  [1656275040, "1009005858244768527585507145"],
-];
-
-const goerliRocketEthDataPoints: RateOracleDataPoint[] = [
-  [1657435372, "1026780389412413279149346221"],
-];
-
-const borrowCompoundUSDCGoerliTrustedDatapoints: RateOracleDataPoint[] = [
-  [1659765253, "1269921134739720773000000000"],
-  [1659789526, "1269955888580957705000000000"],
-  [1659813805, "1269990642422194638000000000"],
-  [1659837864, "1270025396263431571000000000"],
-  [1659861985, "1270060150104668503000000000"],
-  [1659886086, "1270094903945905436000000000"],
-  [1659910328, "1270129664080740928000000000"],
-  [1659934382, "1270164430543297192000000000"],
-  [1659958577, "1270199197100368091000000000"],
-  [1659982682, "1270233963657438989000000000"],
-  [1660006757, "1270268730520167235000000000"],
-  [1660030860, "1270303503776577255000000000"],
-  [1660055553, "1270338278820843895000000000"],
-  [1660079654, "1270373056106306936000000000"],
-  [1660103713, "1270407834303441132000000000"],
-  [1660127807, "1270442613744516329000000000"],
-  [1660151931, "1270477395500834264000000000"],
-  [1660176014, "1270512177257152198000000000"],
-  [1660202544, "1270546959013470133000000000"],
-];
-
-const borrowCompoundETHGoerliTrustedDatapoints: RateOracleDataPoint[] = [
-  [1659765253, "1253897329329515817000000000"],
-  [1659789526, "1254088142387034956000000000"],
-  [1659813805, "1254278983506442512000000000"],
-  [1659837864, "1254469854281890318000000000"],
-  [1659861985, "1254660725057338124000000000"],
-  [1659886086, "1254851634574894171000000000"],
-  [1659910328, "1255042629993880014000000000"],
-  [1659934382, "1255233640587973149000000000"],
-  [1659958577, "1255424651182066283000000000"],
-  [1659982682, "1255615661776159418000000000"],
-  [1660006757, "1255806685577574728000000000"],
-  [1660030860, "1255997824242670783000000000"],
-  [1660055553, "1256188999147124341000000000"],
-  [1660079654, "1256380203793494404000000000"],
-  [1660103713, "1256571437944201722000000000"],
-  [1660127807, "1256762685574084677000000000"],
-  [1660151931, "1256953933203967632000000000"],
-  [1660176014, "1257145216034963865000000000"],
-  [1660202544, "1257336542441742429000000000"],
-];
+import type { ContractsConfig } from "./types";
 
 const TWO_MONTHS_OF_SIX_HOURLY_DATAPOINTS = {
   rateOracleBufferSize: 500,
@@ -66,40 +13,41 @@ export const goerliConfig: ContractsConfig = {
     compoundTokens: [
       {
         name: "cETH",
+        borrow: false,
         address: "0x20572e4c090f15667cf7378e16fad2ea0e2f3eff",
         ...TWO_MONTHS_OF_SIX_HOURLY_DATAPOINTS,
       },
       {
         name: "cDAI",
+        borrow: false,
         address: "0x822397d9a55d0fefd20f5c4bcab33c5f65bd28eb",
         ...TWO_MONTHS_OF_SIX_HOURLY_DATAPOINTS,
       },
       {
         name: "cUSDC",
+        borrow: false,
         address: "0xcec4a43ebb02f9b80916f1c718338169d6d5c1f0",
         ...TWO_MONTHS_OF_SIX_HOURLY_DATAPOINTS,
       },
-    ],
-  },
-  compoundBorrowConfig: {
-    // See tokens list at https://compound.finance/docs#networks
-    compoundTokens: [
       {
         name: "cETH",
+        borrow: true,
         address: "0x20572e4c090f15667cf7378e16fad2ea0e2f3eff",
         ...TWO_MONTHS_OF_SIX_HOURLY_DATAPOINTS,
-        trustedDataPoints: borrowCompoundETHGoerliTrustedDatapoints,
+        daysOfTrustedDataPoints: 10,
       },
       // {
       //   name: "cDAI",
+      //   borrow: true,
       //   address: "0x822397d9a55d0fefd20f5c4bcab33c5f65bd28eb",
       //   ...TWO_MONTHS_OF_SIX_HOURLY_DATAPOINTS,
       // },
       {
         name: "cUSDC",
+        borrow: true,
         address: "0xcec4a43ebb02f9b80916f1c718338169d6d5c1f0",
         ...TWO_MONTHS_OF_SIX_HOURLY_DATAPOINTS,
-        trustedDataPoints: borrowCompoundUSDCGoerliTrustedDatapoints,
+        daysOfTrustedDataPoints: 10,
       },
     ],
   },
@@ -108,7 +56,7 @@ export const goerliConfig: ContractsConfig = {
     lidoOracle: "0x24d8451BC07e7aF4Ba94F69aCDD9ad3c6579D9FB",
     defaults: {
       ...TWO_MONTHS_OF_SIX_HOURLY_DATAPOINTS,
-      trustedDataPoints: goerliStEthDataPoints,
+      daysOfTrustedDataPoints: 10,
     },
   },
   rocketPoolConfig: {
@@ -116,7 +64,7 @@ export const goerliConfig: ContractsConfig = {
     rocketNetworkBalances: "0x28cea7b0f3916c1dba667d3d58ec4836ad843c49",
     defaults: {
       ...TWO_MONTHS_OF_SIX_HOURLY_DATAPOINTS,
-      trustedDataPoints: goerliRocketEthDataPoints,
+      daysOfTrustedDataPoints: 10,
     },
   },
 };

--- a/deployConfig/kovan.ts
+++ b/deployConfig/kovan.ts
@@ -3,7 +3,6 @@ import type { ContractsConfig, RateOracleConfigDefaults } from "./types";
 export const kovanRateOracleConfigDefaults: RateOracleConfigDefaults = {
   rateOracleBufferSize: 200, // For mock token oracle
   minSecondsSinceLastUpdate: 6 * 60 * 60, // FOr mock token oracle. 6 hours
-  trustedDataPoints: [],
 };
 
 export const kovanConfig: ContractsConfig = {
@@ -16,12 +15,7 @@ export const kovanConfig: ContractsConfig = {
     // See tokens list at https://aave.github.io/aave-addresses/kovan.json
     // Mint some here: https://kovan.etherscan.io/address/0x13512979ADE267AB5100878E2e0f485B568328a4#writeContract
     aaveTokens: [
-      // {
-      //   name: "USDT",
-      //   address: "0x13512979ADE267AB5100878E2e0f485B568328a4",
-      //   rateOracleBufferSize: 200,
-      //   minSecondsSinceLastUpdate: 6 * 60 * 60, // 6 hours
-      // },
+      // Non-borrow markets
       {
         name: "USDC",
         address: "0xe22da380ee6B445bb8273C81944ADEB6E8450422",
@@ -33,7 +27,6 @@ export const kovanConfig: ContractsConfig = {
         address: "0x016750ac630f711882812f24dba6c95b9d35856d",
         rateOracleBufferSize: 200,
         minSecondsSinceLastUpdate: 6 * 60 * 60, // 6 hours
-        trustedDataPoints: [],
       },
       {
         name: "WETH",
@@ -71,30 +64,25 @@ export const kovanConfig: ContractsConfig = {
       //   rateOracleBufferSize: 200,
       //   minSecondsSinceLastUpdate: 6 * 60 * 60, // 6 hours
       // },
-    ],
-  },
-  aaveBorrowConfig: {
-    // See deployment info at https://docs.aave.com/developers/v/2.0/deployed-contracts/deployed-contracts
-    aaveLendingPool: "0xE0fBa4Fc209b4948668006B2bE61711b7f465bAe",
-    // Kovan MockUSDT (USDC has no ABI and faucet not working, so USDT easier to mint)
-    // See tokens list at https://aave.github.io/aave-addresses/kovan.json
-    // Mint some here: https://kovan.etherscan.io/address/0x13512979ADE267AB5100878E2e0f485B568328a4#writeContract
-    aaveTokens: [
+
+      // Borrow markets
       {
         name: "USDC",
+        borrow: true,
         address: "0xe22da380ee6B445bb8273C81944ADEB6E8450422",
         rateOracleBufferSize: 200,
         minSecondsSinceLastUpdate: 6 * 60 * 60, // 6 hours
       },
       {
         name: "TUSD",
+        borrow: true,
         address: "0x016750ac630f711882812f24dba6c95b9d35856d",
         rateOracleBufferSize: 200,
         minSecondsSinceLastUpdate: 6 * 60 * 60, // 6 hours
-        trustedDataPoints: [],
       },
       {
         name: "WETH",
+        borrow: true,
         address: "0xd0a1e359811322d97991e03f863a0c30c2cf029c",
         rateOracleBufferSize: 200,
         minSecondsSinceLastUpdate: 6 * 60 * 60, // 6 hours

--- a/deployConfig/localhost.ts
+++ b/deployConfig/localhost.ts
@@ -5,13 +5,7 @@ export const localhostConfig: ContractsConfig = {
   aaveConfig: {
     aaveTokens: [],
   },
-  aaveBorrowConfig: {
-    aaveTokens: [],
-  },
   compoundConfig: {
-    compoundTokens: [],
-  },
-  compoundBorrowConfig: {
     compoundTokens: [],
   },
 };

--- a/deployConfig/mainnet.ts
+++ b/deployConfig/mainnet.ts
@@ -1,74 +1,6 @@
-import type { ContractsConfig, RateOracleDataPoint } from "./types";
+import type { ContractsConfig } from "./types";
 
-const mainnetStEthDataPoints: RateOracleDataPoint[] = [
-  [1656590423, "1076805850648432598627799331"],
-  [1656676823, "1076922239357196746188602894"],
-  [1656763223, "1077039569267086687687246028"],
-  [1656849623, "1077155719316616284685218379"],
-  [1656936023, "1077272225887644039895134408"],
-  [1657022423, "1077389108821174620494509149"],
-  [1657108823, "1077505539378612583110509059"],
-  [1657195223, "1077623031079333642872923949"],
-  [1657281623, "1077740031078281916028542531"],
-  [1657368023, "1077857005650125989376615298"],
-];
-
-const mainnetRocketEthDataPoints: RateOracleDataPoint[] = [
-  [1654153801, "1026502356712851858611688825"],
-  [1654400221, "1026793795816522881011714495"],
-  [1654653662, "1027094919285384123607191853"],
-  [1654908339, "1027407532010818332514656018"],
-  [1655163630, "1027711269610859760832754547"],
-  [1655422235, "1028020261352758203022591045"],
-  [1655679498, "1028327594600088450724742946"],
-  [1655948265, "1028648713128345690215441392"],
-  [1656227854, "1028983791573806158062493864"],
-  [1656507451, "1029316227654002773627484408"],
-  [1656678850, "1029523618065120550016203495"],
-  [1656909442, "1029803630340691797390055876"],
-  [1657140236, "1030082929186402994490724061"],
-  [1657371441, "1030363035676219783347593823"],
-  [1657600825, "1030629617919391988360741953"],
-];
-
-const borrowAaveUSDCMainnetTrustedDatapoints: RateOracleDataPoint[] = [
-  [1658618955, "1109755147923344578270859036"],
-  [1658705395, "1109800811525858567378907794"],
-  [1658791844, "1109847380780342472867486463"],
-  [1658878278, "1109894818250135099335640168"],
-  [1658964143, "1109942844266595658870197351"],
-  [1659050336, "1109992073317241503323476791"],
-  [1659136611, "1110041901548415395110548722"],
-  [1659222426, "1110094318598328195275099717"],
-  [1659308455, "1110146531886525921197028893"],
-  [1659394598, "1110198650640220951402529044"],
-];
-const borrowAaveETHMainnetTrustedDatapoints: RateOracleDataPoint[] = [
-  [1659293973, "1017417175429003949143107039"],
-  [1659382348, "1017471802986665011065209143"],
-  [1659470806, "1017525640360579629633466462"],
-  [1659559993, "1017578765384909374975329286"],
-  [1659648753, "1017631928407994312079157903"],
-  [1659736491, "1017683931915409922815303280"],
-  [1659824625, "1017736749717512736590360219"],
-  [1659912836, "1017789758590383638303157512"],
-  [1660001499, "1017848260571161228686360933"],
-  [1660090543, "1017916178049588760305116077"],
-  [1660179947, "1017988178468620837605923661"],
-];
-const borrowCompoundUSDTMainnetTrustedDatapoints: RateOracleDataPoint[] = [
-  [1659293973, "1156590158125246633000000000"],
-  [1659382348, "1156693385846164973000000000"],
-  [1659470806, "1156793370044702816000000000"],
-  [1659559993, "1156892192141848963000000000"],
-  [1659648753, "1156989357004268035000000000"],
-  [1659736491, "1157084706324075158000000000"],
-  [1659824625, "1157180280453827599000000000"],
-  [1659912836, "1157276004386729727000000000"],
-  [1660001499, "1157371708996419260000000000"],
-  [1660090543, "1157466770574331849000000000"],
-  [1660179947, "1157559434764917645000000000"],
-];
+const DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS = 20;
 
 const ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS = {
   rateOracleBufferSize: 500,
@@ -82,63 +14,75 @@ export const mainnetConfig: ContractsConfig = {
     // See deployment info at https://docs.aave.com/developers/v/2.0/deployed-contracts/deployed-contracts
     aaveLendingPool: "0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9",
     aaveTokens: [
+      // Supply markets
       {
         name: "USDC",
+        borrow: false,
         address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
         ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
+        daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
       },
       {
         name: "DAI",
+        borrow: false,
         address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
+        daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
       },
-    ],
-  },
-  aaveBorrowConfig: {
-    // See deployment info at https://docs.aave.com/developers/v/2.0/deployed-contracts/deployed-contracts
-    aaveLendingPool: "0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9",
-    aaveTokens: [
+      // {
+      //   name: "WETH",
+      //   address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      //   ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
+      //   daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
+      // },
+      // Borrow markets
       {
         name: "USDC",
+        borrow: true,
         address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
         ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
-        trustedDataPoints: borrowAaveUSDCMainnetTrustedDatapoints,
+        daysOfTrustedDataPoints: 20,
       },
       {
         name: "WETH",
+        borrow: true,
         address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
         ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
-        trustedDataPoints: borrowAaveETHMainnetTrustedDatapoints,
+        daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
       },
       // {
       //   name: "DAI",
+      //   borrow: true,
       //   address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
       //   ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
-      //   trustedDataPoints: borrowAaveDAIMainnetTrustedDatapoints,
+      //   daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
       // },
     ],
   },
   compoundConfig: {
     compoundTokens: [
+      // Supply markets
       {
         name: "cDAI",
         address: "0x5d3a536e4d6dbd6114cc1ead35777bab948e3643",
         ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
+        daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
+        borrow: false,
       },
-    ],
-  },
-  compoundBorrowConfig: {
-    compoundTokens: [
+      // Borrow markets
       {
         name: "cUSDT",
         address: "0xf650c3d88d12db855b8bf7d11be6c55a4e07dcc9",
         ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
-        trustedDataPoints: borrowCompoundUSDTMainnetTrustedDatapoints,
+        daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
+        borrow: true,
       },
       // {
       //   name: "cETH",
       //   address: "0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5",
       //   ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
+      //   daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
+      //   borrow: true,
       // },
     ],
   },
@@ -148,7 +92,7 @@ export const mainnetConfig: ContractsConfig = {
     lidoOracle: "0x442af784A788A5bd6F42A01Ebe9F287a871243fb",
     defaults: {
       ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
-      trustedDataPoints: mainnetStEthDataPoints,
+      daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
     },
   },
   rocketPoolConfig: {
@@ -157,7 +101,7 @@ export const mainnetConfig: ContractsConfig = {
     rocketNetworkBalances: "0x138313f102ce9a0662f826fca977e3ab4d6e5539",
     defaults: {
       ...ONE_YEAR_OF_EIGHTEEN_HOURLY_DATAPOINTS,
-      trustedDataPoints: mainnetRocketEthDataPoints,
+      daysOfTrustedDataPoints: DEFAULT_DAYS_OF_TRUSTED_DATA_POINTS,
     },
   },
   skipFactoryDeploy: true, // On mainnet we use a community deployer

--- a/deployConfig/types.ts
+++ b/deployConfig/types.ts
@@ -7,10 +7,8 @@ export interface TokenConfig {
   address: string;
   rateOracleBufferSize: number;
   minSecondsSinceLastUpdate: number;
-  // If migrating, get trusted data points from either:
-  // - an existing rate oracle, using hardhat's queryRateOracle task
-  // - the source of the data, using hardhat's getHistoricalData task
-  trustedDataPoints?: RateOracleDataPoint[];
+  daysOfTrustedDataPoints?: number;
+  borrow?: boolean;
 }
 export interface LpMarginCapDefaults {
   eth: number;
@@ -19,21 +17,13 @@ export interface LpMarginCapDefaults {
 export interface RateOracleConfigDefaults {
   rateOracleBufferSize: number; // For mock token oracle or platforms with only a single token
   minSecondsSinceLastUpdate: number; // For mock token oracle or platforms with only a single token
-  trustedDataPoints: RateOracleDataPoint[]; // For mock token oracle or platforms with only a single token
+  daysOfTrustedDataPoints?: number; // For mock token oracle or platforms with only a single token
 }
 export interface AaveConfig {
   aaveLendingPool?: string;
   aaveTokens: TokenConfig[];
 }
-export interface AaveBorrowConfig {
-  aaveLendingPool?: string;
-  aaveTokens: TokenConfig[];
-}
 export interface CompoundConfig {
-  compoundTokens: TokenConfig[];
-}
-
-export interface CompoundBorrowConfig {
   compoundTokens: TokenConfig[];
 }
 
@@ -50,9 +40,7 @@ export interface RocketPoolConfig {
 export interface ContractsConfig {
   weth?: string;
   aaveConfig?: AaveConfig;
-  aaveBorrowConfig?: AaveBorrowConfig;
   compoundConfig?: CompoundConfig;
-  compoundBorrowConfig?: CompoundBorrowConfig;
   lidoConfig?: LidoConfig;
   rocketPoolConfig?: RocketPoolConfig;
   skipFactoryDeploy?: boolean;

--- a/deployConfig/utils.ts
+++ b/deployConfig/utils.ts
@@ -1,26 +1,7 @@
-import { BigNumberish } from "ethers";
-import type { RateOracleDataPoint } from "./types";
 import { BaseRateOracle } from "../typechain";
 
 const MAX_BUFFER_GROWTH_PER_TRANSACTION = 100;
 const BUFFER_SIZE_SAFETY_FACTOR = 1.2; // The buffer must last for 1.2x as long as the longest expected IRS
-
-interface TrustedDataPoints {
-  trustedTimestamps: number[];
-  trustedObservationValuesInRay: BigNumberish[];
-}
-
-export const convertTrustedRateOracleDataPoints = (
-  trustedDataPoints: RateOracleDataPoint[]
-): TrustedDataPoints => {
-  let trustedTimestamps: number[] = [];
-  let trustedObservationValuesInRay: BigNumberish[] = [];
-  if (trustedDataPoints?.length > 0) {
-    trustedTimestamps = trustedDataPoints.map((e) => e[0]);
-    trustedObservationValuesInRay = trustedDataPoints.map((e) => e[1]);
-  }
-  return { trustedTimestamps, trustedObservationValuesInRay };
-};
 
 export interface RateOracleConfigForTemplate {
   rateOracleAddress: string;

--- a/historicalData/generators/aave.ts
+++ b/historicalData/generators/aave.ts
@@ -1,0 +1,77 @@
+import { BigNumber } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { IAaveV2LendingPool } from "../../typechain";
+import { BlockSpec, Datum, blocksPerDay } from "./common";
+
+export interface AaveDataSpec extends BlockSpec {
+  hre: HardhatRuntimeEnvironment;
+  lendingPool: IAaveV2LendingPool;
+  underlyingAddress: string;
+  borrow: boolean;
+}
+
+// Generator function for Aave data
+async function* aaveDataGenerator(spec: AaveDataSpec): AsyncGenerator<Datum> {
+  const { hre, underlyingAddress, lendingPool } = spec;
+  for (let b = spec.fromBlock; b <= spec.toBlock; b += spec.blockInterval) {
+    try {
+      const block = await hre.ethers.provider.getBlock(b);
+      let rate: BigNumber;
+
+      if (spec.borrow) {
+        rate = await lendingPool.getReserveNormalizedVariableDebt(
+          underlyingAddress,
+          { blockTag: b }
+        );
+      } else {
+        rate = await lendingPool.getReserveNormalizedIncome(underlyingAddress, {
+          blockTag: b,
+        });
+      }
+      yield {
+        blockNumber: b,
+        timestamp: block.timestamp,
+        rate,
+        error: null,
+      };
+    } catch (e: unknown) {
+      yield {
+        blockNumber: b,
+        timestamp: 0,
+        rate: BigNumber.from(0),
+        error: e,
+      };
+    }
+  }
+}
+
+export async function buildAaveDataGenerator(
+  hre: HardhatRuntimeEnvironment,
+  underlyingAddress: string,
+  lookbackDays?: number,
+  borrow = false,
+  overrides?: Partial<AaveDataSpec>
+): Promise<AsyncGenerator<Datum, any, unknown>> {
+  // calculate from and to blocks
+  const currentBlock = await hre.ethers.provider.getBlock("latest");
+
+  const defaults = {
+    fromBlock: lookbackDays
+      ? currentBlock.number - blocksPerDay * lookbackDays
+      : 11367585, // 11367585 = lending pool deploy block on mainnet
+    blockInterval: blocksPerDay,
+    toBlock: currentBlock.number,
+    hre,
+    underlyingAddress,
+    borrow,
+    lendingPool: (await hre.ethers.getContractAt(
+      "IAaveV2LendingPool",
+      "0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9" // mainnet lending pool address
+    )) as IAaveV2LendingPool,
+  };
+
+  return aaveDataGenerator({
+    ...defaults,
+    ...overrides,
+  });
+}

--- a/historicalData/generators/common.ts
+++ b/historicalData/generators/common.ts
@@ -1,0 +1,16 @@
+import { BigNumber } from "ethers";
+
+export interface Datum {
+  blockNumber: number;
+  timestamp: number;
+  rate: BigNumber;
+  error: unknown;
+}
+
+export interface BlockSpec {
+  fromBlock: number; // positive value = absolute block number; negative = offset from toBlock
+  blockInterval: number;
+  toBlock: number; //
+}
+
+export const blocksPerDay = 5 * 60 * 24; // 12 seconds per block = 5 blocks per minute

--- a/historicalData/generators/compound.ts
+++ b/historicalData/generators/compound.ts
@@ -1,0 +1,113 @@
+import { BigNumber } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { ICToken, IERC20Minimal } from "../../typechain";
+import { BlockSpec, Datum, blocksPerDay } from "./common";
+
+export interface CompoundDataSpec extends BlockSpec {
+  hre: HardhatRuntimeEnvironment;
+  cToken: ICToken;
+  borrow: boolean;
+  decimals: number;
+}
+
+// Generator function for Compound data
+async function* compoundDataGenerator(
+  spec: CompoundDataSpec
+): AsyncGenerator<Datum> {
+  const { hre, cToken, decimals } = spec;
+
+  for (let b = spec.fromBlock; b <= spec.toBlock; b += spec.blockInterval) {
+    try {
+      const block = await hre.ethers.provider.getBlock(b);
+      let rate: BigNumber;
+
+      if (spec.borrow) {
+        const borrowRateMantissa = await cToken.borrowRatePerBlock({
+          blockTag: b,
+        });
+        const accrualBlockNumber = await cToken.accrualBlockNumber({
+          blockTag: b,
+        });
+        const blockDelta = BigNumber.from(b).sub(accrualBlockNumber);
+        const simpleInterestFactor = borrowRateMantissa.mul(
+          BigNumber.from(blockDelta)
+        );
+        const borrowIndexPrior = await cToken.borrowIndex({
+          blockTag: b,
+        });
+        rate = simpleInterestFactor
+          .mul(borrowIndexPrior)
+          .div(BigNumber.from(10).pow(18)) // all the above are in wad
+          .add(borrowIndexPrior)
+          .mul(BigNumber.from(10).pow(9)); // scale to ray
+      } else {
+        rate = await cToken.exchangeRateStored({
+          blockTag: b,
+        });
+        if (decimals > 17) {
+          rate = rate.div(BigNumber.from(10).pow(decimals - 17));
+        } else if (decimals < 17) {
+          rate = rate.mul(BigNumber.from(10).pow(17 - decimals));
+        }
+      }
+      yield {
+        blockNumber: b,
+        timestamp: block.timestamp,
+        rate,
+        error: null,
+      };
+    } catch (e: unknown) {
+      yield {
+        blockNumber: b,
+        timestamp: 0,
+        rate: BigNumber.from(0),
+        error: e,
+      };
+    }
+  }
+}
+
+export async function buildCompoundDataGenerator(
+  hre: HardhatRuntimeEnvironment,
+  cTokenAddress: string,
+  lookbackDays?: number,
+  borrow = false,
+  isEther = false,
+  overrides?: Partial<CompoundDataSpec>
+): Promise<AsyncGenerator<Datum, any, unknown>> {
+  // calculate from and to blocks
+  const currentBlock = await hre.ethers.provider.getBlock("latest");
+  const cToken = (await hre.ethers.getContractAt(
+    "ICToken",
+    cTokenAddress
+  )) as ICToken;
+
+  let decimals;
+  if (isEther) {
+    decimals = 18;
+  } else {
+    const underlying = (await hre.ethers.getContractAt(
+      "IERC20Minimal",
+      await cToken.underlying()
+    )) as IERC20Minimal;
+
+    decimals = await underlying.decimals();
+  }
+
+  const defaults = {
+    fromBlock: lookbackDays
+      ? currentBlock.number - blocksPerDay * lookbackDays
+      : 7710760, // 7710760 = cUSDC deployment
+    blockInterval: blocksPerDay,
+    toBlock: currentBlock.number,
+    hre,
+    borrow,
+    decimals,
+    cToken,
+  };
+
+  return compoundDataGenerator({
+    ...defaults,
+    ...overrides,
+  });
+}

--- a/historicalData/generators/lido.ts
+++ b/historicalData/generators/lido.ts
@@ -1,0 +1,88 @@
+import { BigNumber } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { toBn } from "../../test/helpers/toBn";
+import { ILidoOracle, IStETH } from "../../typechain";
+import { BlockSpec, Datum, blocksPerDay } from "./common";
+
+export interface LidoDataSpec extends BlockSpec {
+  stEth: IStETH;
+  lidoOracle: ILidoOracle;
+}
+
+// Generator function for Aave data
+async function* lidoDataGenerator(spec: LidoDataSpec): AsyncGenerator<Datum> {
+  const { stEth, lidoOracle } = spec;
+  for (let b = spec.fromBlock; b <= spec.toBlock; b += spec.blockInterval) {
+    let previousCompletedTimestamp: BigNumber | undefined;
+    try {
+      const rate = await stEth.getPooledEthByShares(toBn(1, 27), {
+        blockTag: b,
+      });
+
+      const epoch = await lidoOracle.getLastCompletedEpochId({
+        blockTag: b,
+      });
+
+      const beaconSpec = await lidoOracle.getBeaconSpec({
+        blockTag: b,
+      });
+
+      const lastCompletedTime = beaconSpec.genesisTime.add(
+        epoch.mul(beaconSpec.slotsPerEpoch).mul(beaconSpec.secondsPerSlot)
+      );
+
+      if (
+        previousCompletedTimestamp &&
+        previousCompletedTimestamp === lastCompletedTime
+      ) {
+        // We already have this data point. Skip it.
+        continue;
+      } else {
+        yield {
+          blockNumber: b,
+          timestamp: lastCompletedTime.toNumber(),
+          rate,
+          error: null,
+        };
+        previousCompletedTimestamp = lastCompletedTime;
+      }
+    } catch (e: unknown) {
+      yield {
+        blockNumber: b,
+        timestamp: 0,
+        rate: BigNumber.from(0),
+        error: e,
+      };
+    }
+  }
+}
+
+export async function buildLidoDataGenerator(
+  hre: HardhatRuntimeEnvironment,
+  lookbackDays?: number,
+  overrides?: Partial<LidoDataSpec>
+): Promise<AsyncGenerator<Datum, any, unknown>> {
+  // calculate from and to blocks
+  const currentBlock = await hre.ethers.provider.getBlock("latest");
+
+  const defaults = {
+    fromBlock: lookbackDays
+      ? currentBlock.number - blocksPerDay * lookbackDays
+      : 11593216, // 11593216 = ~stEth deploy on mainnet
+    blockInterval: blocksPerDay,
+    toBlock: currentBlock.number,
+    stEth: (await hre.ethers.getContractAt(
+      "IStETH",
+      "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84" // mainnet stEth address
+    )) as IStETH,
+    lidoOracle: (await hre.ethers.getContractAt(
+      "ILidoOracle",
+      "0x442af784a788a5bd6f42a01ebe9f287a871243fb" // mainnet lido oracle address
+    )) as ILidoOracle,
+  };
+
+  return lidoDataGenerator({
+    ...defaults,
+    ...overrides,
+  });
+}

--- a/historicalData/generators/rocket.ts
+++ b/historicalData/generators/rocket.ts
@@ -1,0 +1,86 @@
+import { BigNumber } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { toBn } from "../../test/helpers/toBn";
+import { IRocketEth, IRocketNetworkBalances } from "../../typechain";
+import { BlockSpec, Datum, blocksPerDay } from "./common";
+
+export interface RocketDataSpec extends BlockSpec {
+  hre: HardhatRuntimeEnvironment;
+  rocketNetworkBalances: IRocketNetworkBalances;
+  rocketEth: IRocketEth;
+}
+
+// Generator function for Aave data
+async function* rocketDataGenerator(
+  spec: RocketDataSpec
+): AsyncGenerator<Datum> {
+  const { hre, rocketNetworkBalances, rocketEth } = spec;
+  for (let b = spec.fromBlock; b <= spec.toBlock; b += spec.blockInterval) {
+    let previousBlockNumber: number | undefined;
+    try {
+      const rate = await rocketEth.getEthValue(toBn(1, 27), {
+        blockTag: b,
+      });
+
+      const balancesBlockNumber = (
+        await rocketNetworkBalances.getBalancesBlock({
+          blockTag: b,
+        })
+      ).toNumber();
+
+      if (previousBlockNumber && previousBlockNumber === balancesBlockNumber) {
+        // We already have this data point. Skip it.
+        continue;
+      } else {
+        const balancesBlock = await hre.ethers.provider.getBlock(
+          balancesBlockNumber
+        );
+        yield {
+          blockNumber: b,
+          timestamp: balancesBlock.timestamp,
+          rate,
+          error: null,
+        };
+        previousBlockNumber = balancesBlockNumber;
+      }
+    } catch (e: unknown) {
+      yield {
+        blockNumber: b,
+        timestamp: 0,
+        rate: BigNumber.from(0),
+        error: e,
+      };
+    }
+  }
+}
+
+export async function buildRocketDataGenerator(
+  hre: HardhatRuntimeEnvironment,
+  lookbackDays?: number,
+  overrides?: Partial<RocketDataSpec>
+): Promise<AsyncGenerator<Datum, any, unknown>> {
+  // calculate from and to blocks
+  const currentBlock = await hre.ethers.provider.getBlock("latest");
+
+  const defaults = {
+    fromBlock: lookbackDays
+      ? currentBlock.number - blocksPerDay * lookbackDays
+      : 13326304, // 13326304 = ~rocket deploy on mainnet
+    blockInterval: blocksPerDay,
+    toBlock: currentBlock.number,
+    hre,
+    rocketEth: (await hre.ethers.getContractAt(
+      "IRocketEth",
+      "0xae78736Cd615f374D3085123A210448E74Fc6393" // mainnet rocket eth address
+    )) as IRocketEth,
+    rocketNetworkBalances: (await hre.ethers.getContractAt(
+      "IRocketNetworkBalances",
+      "0x138313f102ce9a0662f826fca977e3ab4d6e5539" // mainnet RocketNetworkBalances address
+    )) as IRocketNetworkBalances,
+  };
+
+  return rocketDataGenerator({
+    ...defaults,
+    ...overrides,
+  });
+}

--- a/tasks/getHistoricalData.ts
+++ b/tasks/getHistoricalData.ts
@@ -1,9 +1,6 @@
 import { task, types } from "hardhat/config";
-import { toBn } from "../test/helpers/toBn";
 import {
-  IAaveV2LendingPool,
   ICToken,
-  IERC20Minimal,
   ILidoOracle,
   IRocketEth,
   IRocketNetworkBalances,
@@ -11,30 +8,22 @@ import {
 } from "../typechain";
 import { BigNumber } from "ethers";
 import "@nomiclabs/hardhat-ethers";
-
-// eslint-disable-next-line no-unused-vars
-enum FETCH_STATUS {
-  // eslint-disable-next-line no-unused-vars
-  FAILURE,
-  // eslint-disable-next-line no-unused-vars
-  ALREADY_FETCHED,
-  // eslint-disable-next-line no-unused-vars
-  SUCCESS,
-}
+import { Datum } from "../historicalData/generators/common";
+import { buildAaveDataGenerator } from "../historicalData/generators/aave";
+import { buildLidoDataGenerator } from "../historicalData/generators/lido";
+import { buildRocketDataGenerator } from "../historicalData/generators/rocket";
+import { buildCompoundDataGenerator } from "../historicalData/generators/compound";
 
 // lido
 const lidoStEthMainnetAddress = "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84";
-const lidoStEthMainnetStartBlock = 11593216;
 const lidoOracleAddress = "0x442af784a788a5bd6f42a01ebe9f287a871243fb";
 
 // rocket
 const rocketEthMainnetAddress = "0xae78736Cd615f374D3085123A210448E74Fc6393";
-const rocketEthnMainnetStartBlock = 13326304;
 const RocketNetworkBalancesEthMainnet =
   "0x138313f102ce9a0662f826fca977e3ab4d6e5539";
 
 // compound
-const compoundMainnetStartBlock = 7710760; // cUSDC deployment
 const cTokenAddresses = {
   cDAI: "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
   cUSDC: "0x39aa39c021dfbae8fac545936693ac917d5e7563",
@@ -46,8 +35,6 @@ const cTokenAddresses = {
 };
 
 // aave
-const aaveLendingPoolAddress = "0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9";
-const aaveLendingPoolStartBlock = 11367585;
 const aTokenUnderlyingAddresses = {
   aDAI: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
   aUSDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -57,7 +44,7 @@ const aTokenUnderlyingAddresses = {
   aWETH: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
 };
 
-const blocksPerDay = 6570; // 13.15 seconds per block
+const blocksPerDay = 5 * 60 * 24; // 12 seconds per block = 5 blocks per minute
 
 task("getHistoricalData", "Retrieves the historical rates")
   .addOptionalParam(
@@ -118,6 +105,13 @@ task("getHistoricalData", "Retrieves the historical rates")
       throw new Error(`Exactly one platform must be queried at a time`);
     }
 
+    if (hre.network.name !== "mainnet") {
+      // TODO: support other networks using addresses from deployConfig
+      throw new Error(
+        `Invalid network. Only mainnet data extraction is currently supported`
+      );
+    }
+
     if (taskArgs.borrow && !taskArgs.aave && !taskArgs.compound) {
       throw new Error(`Borrow rates are only supported for aave and compound`);
     }
@@ -125,6 +119,7 @@ task("getHistoricalData", "Retrieves the historical rates")
     // calculate from and to blocks
     const currentBlock = await hre.ethers.provider.getBlock("latest");
 
+    console.log("taskArgs.lookbackDays", taskArgs.lookbackDays);
     let toBlock: number = currentBlock.number;
     const fromBlock: number = taskArgs.fromBlock
       ? taskArgs.fromBlock
@@ -139,7 +134,7 @@ task("getHistoricalData", "Retrieves the historical rates")
     }
 
     // lido
-    const stETH = (await hre.ethers.getContractAt(
+    const stEth = (await hre.ethers.getContractAt(
       "IStETH",
       lidoStEthMainnetAddress
     )) as IStETH;
@@ -151,7 +146,7 @@ task("getHistoricalData", "Retrieves the historical rates")
     )) as ILidoOracle;
 
     // rocket
-    const rocketNetworkBalancesEth = (await hre.ethers.getContractAt(
+    const rocketNetworkBalances = (await hre.ethers.getContractAt(
       "IRocketNetworkBalances",
       RocketNetworkBalancesEthMainnet
     )) as IRocketNetworkBalances;
@@ -166,7 +161,13 @@ task("getHistoricalData", "Retrieves the historical rates")
 
     // general
     let asset = "";
-    let decimals = 0;
+
+    // arrays for results
+    const blocks: number[] = [];
+    const timestamps: number[] = [];
+    const rates: BigNumber[] = [];
+
+    let generator: AsyncGenerator<Datum> | undefined;
 
     // compound
     if (taskArgs.compound) {
@@ -182,16 +183,16 @@ task("getHistoricalData", "Retrieves the historical rates")
         cTokenAddresses[asset as keyof typeof cTokenAddresses]
       )) as ICToken;
 
-      if (taskArgs.token === "ETH") {
-        decimals = 18;
-      } else {
-        const underlying = (await hre.ethers.getContractAt(
-          "IERC20Minimal",
-          await cToken.underlying()
-        )) as IERC20Minimal;
+      const isEther = taskArgs.token === "ETH";
 
-        decimals = await underlying.decimals();
-      }
+      generator = await buildCompoundDataGenerator(
+        hre,
+        cToken.address,
+        undefined,
+        taskArgs.borrow,
+        isEther,
+        { fromBlock, toBlock, blockInterval: taskArgs.blockInterval }
+      );
     }
 
     // aave
@@ -208,6 +209,17 @@ task("getHistoricalData", "Retrieves the historical rates")
         );
       }
 
+      const underlyingTokenAddress =
+        aTokenUnderlyingAddresses[
+          asset as keyof typeof aTokenUnderlyingAddresses
+        ];
+      generator = await buildAaveDataGenerator(
+        hre,
+        underlyingTokenAddress,
+        undefined,
+        taskArgs.borrow,
+        { fromBlock, toBlock, blockInterval: taskArgs.blockInterval }
+      );
       // no need to get decimals
     }
 
@@ -221,7 +233,13 @@ task("getHistoricalData", "Retrieves the historical rates")
         );
       }
 
-      // no need to get decimals
+      generator = await buildLidoDataGenerator(hre, undefined, {
+        stEth,
+        lidoOracle,
+        fromBlock,
+        toBlock,
+        blockInterval: taskArgs.blockInterval,
+      });
     }
 
     // rocket
@@ -234,13 +252,16 @@ task("getHistoricalData", "Retrieves the historical rates")
         );
       }
 
-      // no need to get decimals
+      generator = await buildRocketDataGenerator(hre, undefined, {
+        rocketNetworkBalances,
+        rocketEth,
+        fromBlock,
+        toBlock,
+        blockInterval: taskArgs.blockInterval,
+      });
     }
 
-    const blocks: number[] = [];
-    const timestamps: number[] = [];
-    const rates: BigNumber[] = [];
-
+    // populate output file
     const fs = require("fs");
     const file = taskArgs.borrow
       ? `historicalData/rates/f_borrow_${asset}.csv`
@@ -249,215 +270,26 @@ task("getHistoricalData", "Retrieves the historical rates")
     const header = "date,timestamp,liquidityIndex";
 
     fs.appendFileSync(file, header + "\n");
-    console.log(header);
+    console.log(`block,${header}`);
 
-    for (let b = fromBlock; b <= toBlock; b += taskArgs.blockInterval) {
-      const block = await hre.ethers.provider.getBlock(b);
-      let fetch: FETCH_STATUS = FETCH_STATUS.FAILURE;
-
-      // Lido
-      if (taskArgs.lido && !taskArgs.borrow) {
-        if (b >= lidoStEthMainnetStartBlock) {
-          const r = await stETH.getPooledEthByShares(toBn(1, 27), {
-            blockTag: b,
-          });
-
-          const epoch = await lidoOracle.getLastCompletedEpochId({
-            blockTag: b,
-          });
-
-          const beaconSpec = await lidoOracle.getBeaconSpec({
-            blockTag: b,
-          });
-
-          const lastCompletedTime = beaconSpec.genesisTime.add(
-            epoch.mul(beaconSpec.slotsPerEpoch).mul(beaconSpec.secondsPerSlot)
-          );
-
-          if (
-            timestamps.length === 0 ||
-            timestamps[timestamps.length - 1] < lastCompletedTime.toNumber()
-          ) {
-            blocks.push(b);
-            timestamps.push(lastCompletedTime.toNumber());
-            rates.push(r);
-            fetch = FETCH_STATUS.SUCCESS;
-          } else {
-            fetch = FETCH_STATUS.ALREADY_FETCHED;
-          }
-        }
-      }
-
-      // Rocket
-      if (taskArgs.rocket && !taskArgs.borrow) {
-        if (b >= rocketEthnMainnetStartBlock) {
-          const balancesBlockNumber =
-            await rocketNetworkBalancesEth.getBalancesBlock({
-              blockTag: b,
-            });
-
-          const balancesBlock = await hre.ethers.provider.getBlock(
-            balancesBlockNumber.toNumber()
-          );
-
-          const r = await rocketEth.getEthValue(toBn(1, 27), {
-            blockTag: b,
-          });
-
-          if (
-            blocks.length === 0 ||
-            blocks[blocks.length - 1] < balancesBlockNumber.toNumber()
-          ) {
-            blocks.push(b);
-            timestamps.push(balancesBlock.timestamp);
-            rates.push(r);
-            fetch = FETCH_STATUS.SUCCESS;
-          } else {
-            fetch = FETCH_STATUS.ALREADY_FETCHED;
-          }
-        }
-      }
-
-      // Compound
-      if (taskArgs.compound) {
-        if (b >= compoundMainnetStartBlock) {
-          try {
-            if (cToken && decimals) {
-              if (taskArgs.borrow) {
-                const borrowRateMantissa = await cToken.borrowRatePerBlock({
-                  blockTag: b,
-                });
-                const accrualBlockNumber = await cToken.accrualBlockNumber({
-                  blockTag: b,
-                });
-                const blockDelta = BigNumber.from(b).sub(accrualBlockNumber);
-                const simpleInterestFactor = borrowRateMantissa.mul(
-                  BigNumber.from(blockDelta)
-                );
-                const borrowIndexPrior = await cToken.borrowIndex({
-                  blockTag: b,
-                });
-                const r = simpleInterestFactor
-                  .mul(borrowIndexPrior)
-                  .div(BigNumber.from(10).pow(18)) // all the above are in wad
-                  .add(borrowIndexPrior)
-                  .mul(BigNumber.from(10).pow(9)); // scale to ray
-
-                blocks.push(b);
-                timestamps.push(block.timestamp);
-                rates.push(r);
-                fetch = FETCH_STATUS.SUCCESS;
-
-                // Calculation of instantaneous APY per per https://compound.finance/docs#protocol-math
-                // const ethMantissa = 1e18;
-                // const compoundBlocksPerDay = 6570; // 13.15 seconds per block
-                // const compoundDaysPerYear = 365;
-                // const instantaneousBorrowApy =
-                //   (Math.pow(
-                //     (borrowRateMantissa.toNumber() / ethMantissa) *
-                //       compoundBlocksPerDay +
-                //       1,
-                //     compoundDaysPerYear
-                //   ) -
-                //     1) *
-                //   100;
-                // console.log(
-                //   `Instantaneous borrow APY is ${instantaneousBorrowApy}`
-                // );
-              } else {
-                let r = await cToken.exchangeRateStored({
-                  blockTag: b,
-                });
-                if (decimals > 17) {
-                  r = r.div(BigNumber.from(10).pow(decimals - 17));
-                } else if (decimals < 17) {
-                  r = r.mul(BigNumber.from(10).pow(17 - decimals));
-                }
-
-                blocks.push(b);
-                timestamps.push(block.timestamp);
-                rates.push(r);
-                fetch = FETCH_STATUS.SUCCESS;
-              }
-            }
-          } catch (e) {
-            // console.log("Could not get rate for cToken: ", asset);
-          }
+    if (generator) {
+      // use the platform-specific generator initialised above to get the data points
+      for await (const { blockNumber, timestamp, rate, error } of generator) {
+        if (error) {
+          console.log(`Error retrieving data for block ${blockNumber}`);
         } else {
-          // Before start block but we need a placeholder to keep things aligned
-        }
-      }
-
-      // Aave
-      if (taskArgs.aave) {
-        const aavePool = (await hre.ethers.getContractAt(
-          "IAaveV2LendingPool",
-          aaveLendingPoolAddress
-        )) as IAaveV2LendingPool;
-
-        if (b >= aaveLendingPoolStartBlock) {
-          try {
-            if (taskArgs.borrow) {
-              const r = await aavePool.getReserveNormalizedVariableDebt(
-                aTokenUnderlyingAddresses[
-                  asset as keyof typeof aTokenUnderlyingAddresses
-                ],
-                {
-                  blockTag: b,
-                }
-              );
-
-              blocks.push(b);
-              timestamps.push(block.timestamp);
-              rates.push(r);
-              fetch = FETCH_STATUS.SUCCESS;
-            } else {
-              const r = await aavePool.getReserveNormalizedIncome(
-                aTokenUnderlyingAddresses[
-                  asset as keyof typeof aTokenUnderlyingAddresses
-                ],
-                {
-                  blockTag: b,
-                }
-              );
-
-              blocks.push(b);
-              timestamps.push(block.timestamp);
-              rates.push(r);
-              fetch = FETCH_STATUS.SUCCESS;
-            }
-          } catch (e) {
-            // console.log("Could not get rate for aToken: ", asset);
-          }
-        }
-      }
-
-      switch (fetch) {
-        case FETCH_STATUS.SUCCESS: {
-          const lastBlock = blocks[blocks.length - 1];
-          const lastTimestamp = timestamps[timestamps.length - 1];
-          const lastRate = rates[rates.length - 1];
-
+          blocks.push(blockNumber);
+          timestamps.push(timestamp);
+          rates.push(rate);
           fs.appendFileSync(
             file,
-            `${new Date(
-              lastTimestamp * 1000
-            ).toISOString()},${lastTimestamp},${lastRate}\n`
+            `${new Date(timestamp * 1000).toISOString()},${timestamp},${rate}\n`
           );
           console.log(
-            `${lastBlock},${lastTimestamp},${new Date(
-              lastTimestamp * 1000
-            ).toISOString()},${lastRate}`
+            `${blockNumber},${new Date(
+              timestamp * 1000
+            ).toISOString()},${timestamp},${rate}`
           );
-          break;
-        }
-        case FETCH_STATUS.ALREADY_FETCHED: {
-          console.log("Already fetched.");
-          break;
-        }
-        case FETCH_STATUS.FAILURE: {
-          console.log(`Couldn't fetch at block ${b}`);
-          break;
         }
       }
     }


### PR DESCRIPTION
Also update getHistoricalData task to use the same generators, commonise a bunch of code, and further simplify config by removing hard-coded trusted data points.

Supports Aaave, Compound, Lido and RocketPool. Only gets trusted data points when actually deploying.

Also combines borrow and non-borrow tokens for Aaave & Compound to remove duplicated code.