### PR TITLE
fix: subgraph query positions

### DIFF
--- a/tasks/estimateCashflow.ts
+++ b/tasks/estimateCashflow.ts
@@ -39,7 +39,9 @@ task(
         (await fixedAndVariableMathFactory.deploy()) as FixedAndVariableMathTest;
     }
 
-    let positions: Position[] = await getPositions(true);
+    let positions: Position[] = await getPositions(
+      Math.floor(Date.now() / 1000)
+    );
     if (taskArgs.owners) {
       const filter_owners = taskArgs.owners
         .split(",")

--- a/tasks/getLiquidityDistribution.ts
+++ b/tasks/getLiquidityDistribution.ts
@@ -12,7 +12,9 @@ task("getLiquidityDistribution", "Retrieves the liquidity distribution")
     "Comma-separated pool names as in pool-addresses/mainnet.json"
   )
   .setAction(async (taskArgs, _) => {
-    const positions: Position[] = await getPositions(true);
+    const positions: Position[] = await getPositions(
+      Math.floor(Date.now() / 1000)
+    );
 
     const poolNames: string[] = taskArgs.pools.split(",");
 

--- a/tasks/liquidatePositions.ts
+++ b/tasks/liquidatePositions.ts
@@ -49,7 +49,9 @@ task("liquidatePositions", "Liquidate liquidatable positions")
 
     console.log("margin engine addresses:", marginEngineAddresses);
 
-    const positions: Position[] = await getPositions(true);
+    const positions: Position[] = await getPositions(
+      Math.floor(Date.now() / 1000)
+    );
 
     const currentBlock = await hre.ethers.provider.getBlock("latest");
 


### PR DESCRIPTION
Fixed subgraph querying mechanism when retrieving all positions. It's now getting batches of 1000 positions by filtering by id (as recommended by subgraph here: https://thegraph.com/docs/en/querying/graphql-api/#example-using-and-2), rather than using the `skip` field which had a limit of 5000